### PR TITLE
feat: [IDP-1311] Separate test pipelines by flow

### DIFF
--- a/.devops/idpay-code-review-pipelines.yml
+++ b/.devops/idpay-code-review-pipelines.yml
@@ -1,21 +1,4 @@
-trigger:
-  branches:
-    include:
-      - main
-
-schedules:
-  - cron: "0 6 * * 4" # Runs every Thursday at 06:00:00 UTC
-    displayName: Scheduled Thursday run
-    branches:
-      include:
-        - main
-    always: true
-  - cron: "0 9 * * 1" # Runs every Monday at 09:00:00 UTC
-    displayName: Scheduled Monday run
-    branches:
-      include:
-        - main
-    always: true
+trigger: none
 
 variables:
   # Python version: 3.x
@@ -38,18 +21,13 @@ parameters:
     values:
       - uat
 
-  - name: tag
-    displayName: Target tests tag
-    type: string
-    default: ''
-
 stages:
   - stage: Functional_tests
     dependsOn: [ ]
     pool:
       name: $(selfHostedAgentPool)
     jobs:
-      - job: "run_functional_tests"
+      - job: "Run_functional_tests"
         steps:
           - checkout: self
           - script: |
@@ -70,11 +48,23 @@ stages:
               secureFile: '.secrets.yaml'
           - script: |
               source .venv/bin/activate
-              if [ -z "${{ parameters.tag }}" ]; then
-                pytest --junitxml=tests/reports/pytest/junit.xml -vv
-              else
-                pytest --junitxml=tests/reports/pytest/junit.xml -vv -m "${{ parameters.tag }}"
-              fi
+              behave --junit --junit-directory "tests/reports/behave"
+            displayName: 'Run tests with Behave'
+            env:
+              IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
+              IDPAY_TARGET_ENV: ${{ parameters.env }}
+            continueOnError: true
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'tests/reports/behave/*.xml'
+              testRunTitle: 'Behave Results'
+              searchFolder: $(Build.SourcesDirectory)
+              failTaskOnFailedTests: true
+            continueOnError: true
+          - script: |
+              source .venv/bin/activate
+              pytest --junitxml=tests/reports/pytest/junit.xml -vv
             displayName: 'Run tests with Pytest'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-code-review-pipelines.yml
+++ b/.devops/idpay-code-review-pipelines.yml
@@ -68,43 +68,23 @@ stages:
             displayName: 'Download IDPay secrets'
             inputs:
               secureFile: '.secrets.yaml'
-          #          - script: |
-          #              source .venv/bin/activate
-          #              if [ -z "${{ parameters.tag }}" ]; then
-          #                pytest --junitxml=tests/reports/pytest/junit.xml -vv
-          #              else
-          #                pytest --junitxml=tests/reports/pytest/junit.xml -vv -m "${{ parameters.tag }}"
-          #              fi
-          #            displayName: 'Run tests with Pytest'
-          #            env:
-          #              IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
-          #              IDPAY_TARGET_ENV: ${{ parameters.env }}
-          #            continueOnError: true
-          #          - task: PublishTestResults@2
-          #            continueOnError: true
-          #            inputs:
-          #              testResultsFormat: 'JUnit'
-          #              testResultsFiles: 'tests/reports/pytest/junit.xml'
-          #              testRunTitle: 'Pytest Results'
-          #              searchFolder: $(Build.SourcesDirectory)
-          #              failTaskOnFailedTests: true
           - script: |
               source .venv/bin/activate
               if [ -z "${{ parameters.tag }}" ]; then
-                behave --junit --junit-directory "tests/reports/behave" --tags ~@skip
+                pytest --junitxml=tests/reports/pytest/junit.xml -vv
               else
-                behave --junit --junit-directory "tests/reports/behave" --tags "@${{ parameters.tag }}"
+                pytest --junitxml=tests/reports/pytest/junit.xml -vv -m "${{ parameters.tag }}"
               fi
-            displayName: 'Run tests with Behave'
+            displayName: 'Run tests with Pytest'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
               IDPAY_TARGET_ENV: ${{ parameters.env }}
             continueOnError: true
           - task: PublishTestResults@2
+            continueOnError: true
             inputs:
               testResultsFormat: 'JUnit'
-              testResultsFiles: 'tests/reports/behave/*.xml'
-              testRunTitle: 'Behave Results'
+              testResultsFiles: 'tests/reports/pytest/junit.xml'
+              testRunTitle: 'Pytest Results'
               searchFolder: $(Build.SourcesDirectory)
               failTaskOnFailedTests: true
-            continueOnError: true

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -1,0 +1,90 @@
+trigger:
+  branches:
+    include:
+      - main
+
+schedules:
+  - cron: "0 6 * * 4" # Runs every Thursday at 06:00:00 UTC
+    displayName: Scheduled Thursday run
+    branches:
+      include:
+        - main
+    always: true
+  - cron: "0 9 * * 1" # Runs every Monday at 09:00:00 UTC
+    displayName: Scheduled Monday run
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  # Python version: 3.x
+  pythonVersion: '3.x'
+  # Folder name of this sub-repository
+  working-dir: '.'
+  # Project root folder
+  projectRoot: $(System.DefaultWorkingDirectory)/$(working-dir)
+  selfHostedAgentPool: 'cstar-uat-linux'
+  TIME_OUT: 10
+
+pool:
+  vmImage: 'ubuntu-22.04'
+
+parameters:
+  - name: env
+    displayName: Target Environment
+    type: string
+    default: uat
+    values:
+      - uat
+
+  - name: tag
+    displayName: Target tests tag
+    type: string
+    default: ''
+
+stages:
+  - stage: Functional_tests
+    dependsOn: [ ]
+    pool:
+      name: $(selfHostedAgentPool)
+    jobs:
+      - job: "run_functional_tests"
+        steps:
+          - checkout: self
+          - script: |
+              python3 --version
+              pip3 --version
+            displayName: "Display Python version"
+          - script: |
+              python3 --version
+              python3 -m pip install --user virtualenv
+              python3 -m virtualenv .venv
+              source .venv/bin/activate
+              pip install -r requirements.txt
+            displayName: "Install requirements"
+          - task: DownloadSecureFile@1
+            name: idpay_secrets
+            displayName: 'Download IDPay secrets'
+            inputs:
+              secureFile: '.secrets.yaml'
+          - script: |
+              source .venv/bin/activate
+              if [ -z "${{ parameters.tag }}" ]; then
+                behave --junit --junit-directory "tests/reports/behave" --tags ~@skip
+              else
+                behave --junit --junit-directory "tests/reports/behave" --tags "@${{ parameters.tag }}"
+              fi
+            displayName: 'Run tests with Behave'
+            env:
+              IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
+              IDPAY_TARGET_ENV: ${{ parameters.env }}
+            continueOnError: true
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'tests/reports/behave/*.xml'
+              testRunTitle: 'Behave Results'
+              searchFolder: $(Build.SourcesDirectory)
+              failTaskOnFailedTests: true
+            continueOnError: true

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -49,7 +49,7 @@ stages:
     pool:
       name: $(selfHostedAgentPool)
     jobs:
-      - job: "Run functional tests"
+      - job: "Run_functional_tests"
         steps:
           - checkout: self
           - script: |

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,8 +70,10 @@ stages:
               secureFile: '.secrets.yaml'
           - script: |
               source .venv/bin/activate
-              if [ -z "${{ parameters.tag }}" ]; then
+              if [ -z "${{ parameters.tag }}" ] || [ "${{ parameters.tag }}" = "all_skip" ]; then
                 behave --junit --junit-directory "tests/reports/behave" --tags ~@skip
+              elif [ "${{ parameters.tag }}" = "all" ]; then
+                behave --junit --junit-directory "tests/reports/behave"
               else
                 behave --junit --junit-directory "tests/reports/behave" --tags "@${{ parameters.tag }}"
               fi

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -39,7 +39,7 @@ parameters:
       - uat
 
   - name: tag
-    displayName: Target tests tag
+    displayName: Target tests tag (use unquoted "all_skip" to run every un-skipped test or "all" to run every test)
     type: string
     default: ''
 
@@ -49,7 +49,7 @@ stages:
     pool:
       name: $(selfHostedAgentPool)
     jobs:
-      - job: "run_functional_tests"
+      - job: "Run functional tests"
         steps:
           - checkout: self
           - script: |

--- a/.devops/idpay-functional-testing-refund-flow.yml
+++ b/.devops/idpay-functional-testing-refund-flow.yml
@@ -1,7 +1,4 @@
-trigger:
-  branches:
-    include:
-      - main
+trigger: none
 
 schedules:
   - cron: "0 6 * * 4" # Runs every Thursday at 06:00:00 UTC

--- a/.devops/idpay-functional-testing-refund-flow.yml
+++ b/.devops/idpay-functional-testing-refund-flow.yml
@@ -49,7 +49,7 @@ stages:
     pool:
       name: $(selfHostedAgentPool)
     jobs:
-      - job: "Run functional tests"
+      - job: "Run_functional_tests"
         steps:
           - checkout: self
           - script: |

--- a/.devops/idpay-functional-testing-refund-flow.yml
+++ b/.devops/idpay-functional-testing-refund-flow.yml
@@ -1,0 +1,90 @@
+trigger:
+  branches:
+    include:
+      - main
+
+schedules:
+  - cron: "0 6 * * 4" # Runs every Thursday at 06:00:00 UTC
+    displayName: Scheduled Thursday run
+    branches:
+      include:
+        - main
+    always: true
+  - cron: "0 9 * * 1" # Runs every Monday at 09:00:00 UTC
+    displayName: Scheduled Monday run
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  # Python version: 3.x
+  pythonVersion: '3.x'
+  # Folder name of this sub-repository
+  working-dir: '.'
+  # Project root folder
+  projectRoot: $(System.DefaultWorkingDirectory)/$(working-dir)
+  selfHostedAgentPool: 'cstar-uat-linux'
+  TIME_OUT: 10
+
+pool:
+  vmImage: 'ubuntu-22.04'
+
+parameters:
+  - name: env
+    displayName: Target Environment
+    type: string
+    default: uat
+    values:
+      - uat
+
+  - name: tag
+    displayName: Target tests tag (use unquoted "all" to run every un-skipped test)
+    type: string
+    default: ''
+
+stages:
+  - stage: Functional_tests
+    dependsOn: [ ]
+    pool:
+      name: $(selfHostedAgentPool)
+    jobs:
+      - job: "Run functional tests"
+        steps:
+          - checkout: self
+          - script: |
+              python3 --version
+              pip3 --version
+            displayName: "Display Python version"
+          - script: |
+              python3 --version
+              python3 -m pip install --user virtualenv
+              python3 -m virtualenv .venv
+              source .venv/bin/activate
+              pip install -r requirements.txt
+            displayName: "Install requirements"
+          - task: DownloadSecureFile@1
+            name: idpay_secrets
+            displayName: 'Download IDPay secrets'
+            inputs:
+              secureFile: '.secrets.yaml'
+          - script: |
+              source .venv/bin/activate
+              if [ -z "${{ parameters.tag }}" ] || [ "${{ parameters.tag }}" = "all" ]; then
+                pytest --junitxml=tests/reports/pytest/junit.xml -vv
+              else
+                pytest --junitxml=tests/reports/pytest/junit.xml -vv -m "${{ parameters.tag }}"
+              fi
+            displayName: 'Run tests with Pytest'
+            env:
+              IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
+              IDPAY_TARGET_ENV: ${{ parameters.env }}
+            continueOnError: true
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'tests/reports/pytest/junit.xml'
+              testRunTitle: 'Pytest Results'
+              searchFolder: $(Build.SourcesDirectory)
+              failTaskOnFailedTests: true
+            continueOnError: true


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to separate Azure DevOps pipelines in discount and refund flow.
### List of changes
- separate the main pipeline in 2 pipelines
<!--- Describe your changes in detail -->

### Motivation and context
This change allows to test the 2 currently supported flows independently.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [ ] Test suite

### Test type

- [ ] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Pipelines' secure file
- [ ] `.secrets_template.yaml`
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
