### PR TITLE
fix: [IDP-1559] Obtain correctly rate limit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,9 +41,10 @@
 
 ### Did you update secrets accordingly?
 
-- [ ] `.secrets_template.yaml`
-- [ ] Pipelines' secure file
-- [ ] Confluence
+- [ ] Yes
+  - [ ] `.secrets_template.yaml`
+  - [ ] Pipelines' secure file
+  - [ ] Confluence
 - [ ] Not needed
 - [ ] No (_please provide further information_)
 

--- a/api/token_io.py
+++ b/api/token_io.py
@@ -21,7 +21,7 @@ def login(tax_code):
 
 
 def introspect(token):
-    """API to introspect an IOtoken and get user data
+    """API to introspect an IO token and get user data
         :param token: IO token to introspect
         :returns: the response of the call.
         :rtype: requests.Response

--- a/bdd/features/pilot/pilot_cancellation.feature
+++ b/bdd/features/pilot/pilot_cancellation.feature
@@ -65,7 +65,7 @@ Feature: A transaction can be cancelled by the merchant
   @Scontoditipo1
   Scenario: The transaction cancellation fails if done shortly after the confirmation but can be cancelled later
     Given the merchant 1 generates the transaction X of amount 15000 cents
-    And the citizen A confirms the transaction X
+    And the citizen A confirms, immediately before the next step, the transaction X
     And the merchant 1 fails cancelling the transaction X
     When 1 second/s pass
     And the merchant 1 cancels the transaction X
@@ -76,7 +76,7 @@ Feature: A transaction can be cancelled by the merchant
   @MIL
   Scenario: The transaction cancellation through MIL fails if done shortly after the confirmation but can be cancelled later
     Given the merchant 1 generates the transaction X of amount 15000 cents through MIL
-    And the citizen A confirms the transaction X
+    And the citizen A confirms, immediately before the next step, the transaction X
     And the merchant 1 fails cancelling the transaction X through MIL
     When 1 second/s pass
     And the merchant 1 cancels the transaction X through MIL

--- a/bdd/features/pilot/pilot_cancellation.feature
+++ b/bdd/features/pilot/pilot_cancellation.feature
@@ -48,7 +48,7 @@ Feature: A transaction can be cancelled by the merchant
   @Scontoditipo1
   Scenario: The transaction cancellation fails if done shortly after the confirmation
     Given the merchant 1 generates the transaction X of amount 15000 cents
-    And the citizen A confirms the transaction X
+    And the citizen A confirms, immediately before the next step, the transaction X
     When the merchant 1 tries to cancel the transaction X
     Then the latest cancellation fails exceeding rate limit
 
@@ -57,7 +57,7 @@ Feature: A transaction can be cancelled by the merchant
   @MIL
   Scenario: The transaction cancellation through MIL fails if done shortly after the confirmation
     Given the merchant 1 generates the transaction X of amount 15000 cents through MIL
-    And the citizen A confirms the transaction X
+    And the citizen A confirms, immediately before the next step, the transaction X
     When the merchant 1 tries to cancel the transaction X through MIL
     Then the latest cancellation fails exceeding rate limit
 

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -354,7 +354,7 @@ Feature: A transaction is generated, authorized and confirmed
     And the merchant 1 generates the transaction X of amount 3000 cents
     And the merchant 1 generates the transaction Y of amount 3000 cents
     And the merchant 1 generates the transaction Z of amount 3000 cents
-    And the citizen A confirms the transaction X
+    And the citizen A confirms, immediately before the next step, the transaction X
     And the citizen B confirms, immediately before the next step, the transaction Y
     When the citizen B tries to confirm the transaction Z
     Then the transaction Z is exceeding rate limit
@@ -370,7 +370,7 @@ Feature: A transaction is generated, authorized and confirmed
     And the merchant 1 generates the transaction X of amount 3000 cents through MIL
     And the merchant 1 generates the transaction Y of amount 3000 cents through MIL
     And the merchant 1 generates the transaction Z of amount 3000 cents through MIL
-    And the citizen A confirms the transaction X
+    And the citizen A confirms, immediately before the next step, the transaction X
     And the citizen B confirms, immediately before the next step, the transaction Y
     When the citizen B tries to confirm the transaction Z
     Then the transaction Z is exceeding rate limit

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -346,50 +346,98 @@ Feature: A transaction is generated, authorized and confirmed
 
   @transaction
   @Scontoditipo1
-  Scenario: 2 transactions cannot be authorized by the same citizen if at least one seconds has not passed between authorizations.
+  Scenario: 2 transactions cannot be authorized by the same citizen if at least one second has not passed between authorizations.
+    Given the merchant 1 is qualified
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 3000 cents
+    And the merchant 1 generates the transaction Y of amount 3000 cents
+    And the citizen A confirms, immediately before the next step, the transaction X
+    When the citizen A tries to confirm the transaction Y
+    Then the transaction Y is exceeding rate limit
+
+  @transaction
+  @Scontoditipo1
+  @MIL
+  Scenario: 2 transactions, created through MIL, cannot be authorized by the same citizen if at least one second has not passed between authorizations.
+    Given the merchant 1 is qualified
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 3000 cents through MIL
+    And the merchant 1 generates the transaction Y of amount 3000 cents through MIL
+    And the citizen A confirms, immediately before the next step, the transaction X
+    When the citizen A tries to confirm the transaction Y
+    Then the transaction Y is exceeding rate limit
+
+  @transaction
+  @Scontoditipo1
+  Scenario: 2 transactions can be authorized by different citizens even if one second has not passed between authorizations.
     Given the merchant 1 is qualified
     And the citizen A is onboard
     And the citizen B is 20 years old at most
     And the citizen B is onboard
     And the merchant 1 generates the transaction X of amount 3000 cents
     And the merchant 1 generates the transaction Y of amount 3000 cents
-    And the merchant 1 generates the transaction Z of amount 3000 cents
     And the citizen A confirms, immediately before the next step, the transaction X
-    And the citizen B confirms, immediately before the next step, the transaction Y
-    When the citizen B tries to confirm the transaction Z
-    Then the transaction Z is exceeding rate limit
+    When the citizen B tries to confirm the transaction Y
+    Then the transaction X is authorized
+    And the transaction Y is authorized
 
   @transaction
   @Scontoditipo1
   @MIL
-  Scenario: 2 transactions, created through MIL, cannot be authorized by the same citizen if at least one seconds has not passed between authorizations.
+  Scenario: 2 transactions, created though MIL, can be authorized by different citizens even if one second has not passed between authorizations.
     Given the merchant 1 is qualified
     And the citizen A is onboard
     And the citizen B is 20 years old at most
     And the citizen B is onboard
     And the merchant 1 generates the transaction X of amount 3000 cents through MIL
     And the merchant 1 generates the transaction Y of amount 3000 cents through MIL
-    And the merchant 1 generates the transaction Z of amount 3000 cents through MIL
     And the citizen A confirms, immediately before the next step, the transaction X
-    And the citizen B confirms, immediately before the next step, the transaction Y
-    When the citizen B tries to confirm the transaction Z
-    Then the transaction Z is exceeding rate limit
+    When the citizen B tries to confirm the transaction Y
+    Then the transaction X is authorized
+    And the transaction Y is authorized
+
+  @transaction
+  @Scontoditipo1
+  Scenario: One second after a rate limit failure the transaction can be authorized.
+    Given the merchant 1 is qualified
+    And the citizen A is 20 years old at most
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 3000 cents
+    And the merchant 1 generates the transaction Y of amount 3000 cents
+    And the citizen A confirms, immediately before the next step, the transaction X
+    And the citizen A tries to confirm the transaction Y
+    And the transaction Y is exceeding rate limit
+    When 1 second/s pass
+    And the citizen A confirms the transaction Y
+    Then the transaction Y is authorized
+
+  @transaction
+  @Scontoditipo1
+  @MIL
+  Scenario: One second after a rate limit failure the transaction, created through MIL, can be authorized.
+    Given the merchant 1 is qualified
+    And the citizen A is 20 years old at most
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 3000 cents through MIL
+    And the merchant 1 generates the transaction Y of amount 3000 cents through MIL
+    And the citizen A confirms, immediately before the next step, the transaction X
+    And the citizen A tries to confirm the transaction Y
+    And the transaction Y is exceeding rate limit
+    When 1 second/s pass
+    And the citizen A confirms the transaction Y
+    Then the transaction Y is authorized
 
   @transaction
   @Scontoditipo1
   Scenario: 2 transactions are authorized correctly by the same citizen if authorizations are 1 second apart one from the other.
     Given the merchant 1 is qualified
     And the citizen A is onboard
-    And the citizen B is 20 years old at most
-    And the citizen B is onboard
     And the merchant 1 generates the transaction X of amount 3000 cents
     And the merchant 1 generates the transaction Y of amount 3000 cents
-    And the merchant 1 generates the transaction Z of amount 3000 cents
     And the citizen A confirms the transaction X
-    And the citizen B confirms the transaction Y
     When 1 second/s pass
-    And the citizen B tries to confirm the transaction Z
-    Then the transaction Z is authorized
+    And the citizen A tries to confirm the transaction Y
+    Then the transaction Y is authorized
 
   @transaction
   @Scontoditipo1
@@ -397,16 +445,12 @@ Feature: A transaction is generated, authorized and confirmed
   Scenario: 2 transactions, created through MIL, are authorized correctly by the same citizen if authorizations are 1 second apart one from the other.
     Given the merchant 1 is qualified
     And the citizen A is onboard
-    And the citizen B is 20 years old at most
-    And the citizen B is onboard
     And the merchant 1 generates the transaction X of amount 3000 cents through MIL
     And the merchant 1 generates the transaction Y of amount 3000 cents through MIL
-    And the merchant 1 generates the transaction Z of amount 3000 cents through MIL
     And the citizen A confirms the transaction X
-    And the citizen B confirms the transaction Y
     When 1 second/s pass
-    And the citizen B tries to confirm the transaction Z
-    Then the transaction Z is authorized
+    And the citizen A tries to confirm the transaction Y
+    Then the transaction Y is authorized
 
   @transaction
   @Scontoditipo1

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -384,7 +384,7 @@ Feature: A transaction is generated, authorized and confirmed
   @transaction
   @Scontoditipo1
   @MIL
-  Scenario: 2 transactions, created though MIL, can be authorized by different citizens even if one second has not passed between authorizations.
+  Scenario: 2 transactions, created through MIL, can be authorized by different citizens even if one second has not passed between authorizations.
     Given the merchant 1 is qualified
     And the citizen A is onboard
     And the citizen B is 20 years old at most

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -355,7 +355,7 @@ Feature: A transaction is generated, authorized and confirmed
     And the merchant 1 generates the transaction Y of amount 3000 cents
     And the merchant 1 generates the transaction Z of amount 3000 cents
     And the citizen A confirms the transaction X
-    And the citizen B confirms the transaction Y
+    And the citizen B confirms, immediately before the next step, the transaction Y
     When the citizen B tries to confirm the transaction Z
     Then the transaction Z is exceeding rate limit
 
@@ -371,7 +371,7 @@ Feature: A transaction is generated, authorized and confirmed
     And the merchant 1 generates the transaction Y of amount 3000 cents through MIL
     And the merchant 1 generates the transaction Z of amount 3000 cents through MIL
     And the citizen A confirms the transaction X
-    And the citizen B confirms the transaction Y
+    And the citizen B confirms, immediately before the next step, the transaction Y
     When the citizen B tries to confirm the transaction Z
     Then the transaction Z is exceeding rate limit
 

--- a/bdd/features/tipo3/_transaction.feature
+++ b/bdd/features/tipo3/_transaction.feature
@@ -4,7 +4,7 @@ Feature: A transaction is generated, authorized and confirmed
     Given the initiative is "Scontoditipo3"
     And the initiative's budget is totally allocated
 
-  @Transaction
+  @transaction
   @Scontoditipo3
   Scenario: The merchant tries to generate a transaction when the budget of the initiative is totally allocated
     Given the merchant 2 is qualified

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -36,6 +36,8 @@ def step_when_merchant_tries_to_create_a_transaction(context, merchant_name, trx
         merchant_id=curr_merchant_id
     )
 
+    context.transactions[trx_name] = context.latest_create_transaction_response
+
 
 @when(
     'the merchant {merchant_name} tries to generate the transaction {trx_name} of amount {amount_cents} cents through MIL')
@@ -51,10 +53,13 @@ def step_when_merchant_tries_to_create_a_transaction_mil(context, merchant_name,
         merchant_fiscal_code=curr_merchant_fiscal_code
     )
 
+    context.transactions[trx_name] = context.latest_create_transaction_response
+
 
 @when(
     'the merchant {merchant_name} tries to generate the transaction {trx_name} of amount {amount_cents} cents with wrong acquirer ID')
-def step_when_merchant_tries_to_create_a_transaction_with_wrong_acquirer_id(context, merchant_name, amount_cents):
+def step_when_merchant_tries_to_create_a_transaction_with_wrong_acquirer_id(context, merchant_name, trx_name,
+                                                                            amount_cents):
     curr_merchant_id = context.merchants[merchant_name]['id']
     context.latest_merchant_id = curr_merchant_id
 
@@ -65,6 +70,8 @@ def step_when_merchant_tries_to_create_a_transaction_with_wrong_acquirer_id(cont
         merchant_id=curr_merchant_id,
         acquirer_id='WRONG_ACQUIRER_ID'
     )
+
+    context.transactions[trx_name] = context.latest_create_transaction_response
 
 
 @given('the merchant {merchant_name} generates the transaction {trx_name} of amount {amount_cents} cents')

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -332,6 +332,7 @@ def step_when_citizen_rapidly_confirms_the_transactions(context, citizen_name, t
     context.associated_citizen[trx_name] = context.citizens_fc[citizen_name]
 
 
+@given('the citizen {citizen_name} tries to confirm the transaction {trx_name}')
 @when('the citizen {citizen_name} tries to confirm the transaction {trx_name}')
 def step_citizen_tries_pre_authorize_transaction(context, citizen_name, trx_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -54,7 +54,7 @@ def step_when_merchant_tries_to_create_a_transaction_mil(context, merchant_name,
 
 @when(
     'the merchant {merchant_name} tries to generate the transaction {trx_name} of amount {amount_cents} cents with wrong acquirer ID')
-def step_when_merchant_tries_to_create_a_transaction_with_wrong_acquirer_id(context, merchant_name, trx_name, amount_cents):
+def step_when_merchant_tries_to_create_a_transaction_with_wrong_acquirer_id(context, merchant_name, amount_cents):
     curr_merchant_id = context.merchants[merchant_name]['id']
     context.latest_merchant_id = curr_merchant_id
 
@@ -295,15 +295,7 @@ def step_when_citizen_confirms_transaction(context, citizen_name, trx_name):
 
     step_check_named_transaction_status(context=context, trx_name=trx_name, expected_status='AUTHORIZED')
 
-    if citizen_name not in context.accrued_per_citizen.keys():
-        context.accrued_per_citizen[citizen_name] = res.json()['reward']
-    else:
-        context.accrued_per_citizen[citizen_name] = context.accrued_per_citizen[citizen_name] + res.json()['reward']
-
-    if citizen_name not in context.trxs_per_citizen.keys():
-        context.trxs_per_citizen[citizen_name] = 1
-    else:
-        context.trxs_per_citizen[citizen_name] = context.trxs_per_citizen[citizen_name] + 1
+    update_user_counters(context=context, citizen_name=citizen_name, reward=res.json()['reward'])
 
     retry_timeline(expected=timeline_operations.transaction, request=timeline,
                    num_required=context.trxs_per_citizen[citizen_name], token=curr_token_io,
@@ -318,9 +310,6 @@ def step_when_citizen_confirms_transaction(context, citizen_name, trx_name):
                                    merchant_id=associated_merchant_id,
                                    expected_status='AUTHORIZED'
                                    )
-
-    context.total_accrued = context.total_accrued + res.json()['reward']
-    context.num_new_trxs = context.num_new_trxs + 1
 
     context.associated_citizen[trx_name] = context.citizens_fc[citizen_name]
 
@@ -535,3 +524,15 @@ def step_citizen_tries_to_cancel_a_transaction(context, citizen_name, trx_name):
     res = delete_payment_citizen(trx_code=trx_code,
                                  token=token_io)
     context.latest_citizen_cancellation_response = res
+
+
+def update_user_counters(context, citizen_name, reward):
+    if citizen_name not in context.accrued_per_citizen.keys():
+        context.accrued_per_citizen[citizen_name] = reward
+        context.trxs_per_citizen[citizen_name] = 1
+    else:
+        context.accrued_per_citizen[citizen_name] = context.accrued_per_citizen[citizen_name] + reward
+        context.trxs_per_citizen[citizen_name] = context.trxs_per_citizen[citizen_name] + 1
+
+    context.total_accrued = context.total_accrued + reward
+    context.num_new_trxs = context.num_new_trxs + 1

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -325,6 +325,17 @@ def step_when_citizen_confirms_transaction(context, citizen_name, trx_name):
     context.associated_citizen[trx_name] = context.citizens_fc[citizen_name]
 
 
+@given('the citizen {citizen_name} confirms, immediately before the next step, the transaction {trx_name}')
+def step_when_citizen_rapidly_confirms_the_transactions(context, citizen_name, trx_name):
+    curr_token_io = get_io_token(context.citizens_fc[citizen_name])
+
+    trx_name = context.transactions[trx_name]['trxCode']
+
+    res = complete_transaction_confirmation(context=context, trx_code=trx_name, token_io=curr_token_io)
+    update_user_counters(context=context, citizen_name=citizen_name, reward=res.json()['reward'])
+    context.associated_citizen[trx_name] = context.citizens_fc[citizen_name]
+
+
 @when('the citizen {citizen_name} tries to confirm the transaction {trx_name}')
 def step_citizen_tries_pre_authorize_transaction(context, citizen_name, trx_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add dedicated step that skip asynchronous checks after a transaction confirmation.

### List of changes
- add step
- modify existing scenarios
- miscellaneous refactors
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can consistently test the rate limit on wallet operations.

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] `.secrets_template.yaml`
- [ ] Pipelines' secure file
- [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
