### PR TITLE
feat: [IDP-1586] Add mock ISEE API

### DIFF
--- a/api/mil.py
+++ b/api/mil.py
@@ -32,6 +32,21 @@ def post_merchant_create_transaction_acquirer_mil(initiative_id,
     return response
 
 
+def get_initiative_list_mil(merchant_fiscal_code: str,
+                            merchant_id: str):
+    cert = load_certificates()
+    response = requests.get(
+        f'{settings.base_path.CSTAR}{settings.IDPAY.domain}{settings.IDPAY.MIL.domain}{settings.IDPAY.endpoints.payment.path}{settings.IDPAY.endpoints.payment.qr_code.path}{settings.IDPAY.endpoints.payment.qr_code.merchant}/initiatives',
+        cert=cert,
+        headers={
+            settings.API_KEY_HEADER: secrets.api_key.IDPAY_MIL_PRODUCT,
+            'x-merchant-fiscalcode': merchant_fiscal_code,
+            'x-merchant-id': merchant_id
+        }
+    )
+    return response
+
+
 def get_transaction_detail_mil(transaction_id,
                                acquirer_id: str = settings.idpay.acquirer_id,
                                merchant_fiscal_code: str = '12345678901'

--- a/api/mock.py
+++ b/api/mock.py
@@ -1,0 +1,27 @@
+import requests
+
+from conf.configuration import secrets
+from conf.configuration import settings
+
+
+def control_mocked_isee(fc: str,
+                        isee: float):
+    """API control mocked ISEE value for a citizen
+        :param fc: Fiscal code of the citizen
+        :param isee: Desired ISEE to set for the user
+        :returns: the response of the call.
+        :rtype: requests.Response
+    """
+    return requests.post(f'{settings.base_path.IO}{settings.IDPAY.domain}{settings.IDPAY.endpoints.mock.isee}',
+                         headers={
+                             'Content-Type': 'application/json',
+                             settings.API_KEY_HEADER: secrets.api_key.RTD_Mock_API_Product,
+                             'Fiscal-Code': fc,
+                         },
+                         json={
+                             'iseeTypeMap': {
+                                 'ORDINARIO': isee
+                             }
+                         },
+                         timeout=settings.default_timeout
+                         )

--- a/bdd/features/pilot/pilot_onboarding.feature
+++ b/bdd/features/pilot/pilot_onboarding.feature
@@ -65,15 +65,6 @@ Feature: A citizen A onboards the pilot initiative
 
   @onboarding
   @Scontoditipo1
-  @need_fix
-  Scenario: User onboarded tries to onboard again
-    Given the citizen A is 23 years old at most
-    And the citizen A onboarded
-    When the citizen A tries to onboard
-    Then the onboard of A is KO
-
-  @onboarding
-  @Scontoditipo1
   Scenario: User in age range with self-declared correct criteria tries onboarding unsuccessfully
     Given the citizen A is 25 years old tomorrow
     And the citizen A accepts terms and condition

--- a/bdd/steps/dataset_steps.py
+++ b/bdd/steps/dataset_steps.py
@@ -4,6 +4,7 @@ import random
 import pytz
 from behave import given
 
+from api.mock import control_mocked_isee
 from api.token_io import introspect
 from conf.configuration import settings
 from util.dataset_utility import fake_fc
@@ -48,6 +49,12 @@ def step_citizen_fc_from_name_age_and_precision(context, citizen_name: str, age:
     context.latest_citizen_fc = citizen_fc
     context.latest_token_io = get_io_token(citizen_fc)
     context.citizens_fc[citizen_name] = citizen_fc
+
+
+@given('the citizen {citizen_name} has ISEE {isee}')
+def step_set_citizen_isee(context, citizen_name: str, isee: int):
+    res = control_mocked_isee(fc=context.citizens_fc[citizen_name], isee=int(isee))
+    assert res.status_code == 201
 
 
 @given('the transaction is created before fruition period')

--- a/settings.yaml
+++ b/settings.yaml
@@ -71,6 +71,8 @@ IDPAY:
       unprocessed: '/transactions'
     merchant:
       path: '/idpaymerchant'
+    mock:
+      isee: '/mock/citizen/isee'
   acquirer_id: 'PAGOPA'
 RTD:
   domain: "/rtd"

--- a/tests/test_cashback_like/test_onboarding_io.py
+++ b/tests/test_cashback_like/test_onboarding_io.py
@@ -7,9 +7,11 @@ import string
 
 import pytest
 
+from api.idpay import get_initiative_statistics
 from api.idpay import timeline
 from api.idpay import wallet
 from api.onboarding_io import accept_terms_and_condition
+from api.onboarding_io import pdnd_autocertification
 from api.token_io import introspect
 from api.token_io import login
 from conf.configuration import secrets
@@ -17,6 +19,7 @@ from conf.configuration import settings
 from util.dataset_utility import fake_fc
 from util.dataset_utility import fake_temporary_fc
 from util.dataset_utility import get_random_unicode
+from util.utility import check_statistics
 from util.utility import get_io_token
 from util.utility import onboard_io
 
@@ -133,3 +136,34 @@ def test_timeline_without_ever_onboard():
     assert res.status_code == 404
     res = timeline(initiative_id=initiative_id, token=token_io)
     assert res.status_code == 404
+
+
+@pytest.mark.IO
+@pytest.mark.onboard
+def test_onboard_two_times():
+    """Repeat the onboarding of the same citizen and check if the counters change
+    """
+    organization_id = secrets.organization_id
+    old_statistics = get_initiative_statistics(organization_id=organization_id, initiative_id=initiative_id).json()
+
+    test_fc = fake_temporary_fc()
+
+    onboard_io(test_fc, initiative_id).json()
+    check_statistics(organization_id=organization_id, initiative_id=initiative_id, old_statistics=old_statistics,
+                     onboarded_citizen_count_increment=1, accrued_rewards_increment=0,
+                     rewarded_trxs_increment=0, skip_trx_check=True)
+    old_statistics = get_initiative_statistics(organization_id=organization_id, initiative_id=initiative_id).json()
+
+    token = get_io_token(test_fc)
+    res = accept_terms_and_condition(token, initiative_id)
+    assert res.status_code == 204
+    check_statistics(organization_id=organization_id, initiative_id=initiative_id, old_statistics=old_statistics,
+                     onboarded_citizen_count_increment=0, accrued_rewards_increment=0,
+                     rewarded_trxs_increment=0, skip_trx_check=True)
+    old_statistics = get_initiative_statistics(organization_id=organization_id, initiative_id=initiative_id).json()
+
+    res = pdnd_autocertification(token, initiative_id)
+    assert res.status_code == 202
+    check_statistics(organization_id=organization_id, initiative_id=initiative_id, old_statistics=old_statistics,
+                     onboarded_citizen_count_increment=0, accrued_rewards_increment=0,
+                     rewarded_trxs_increment=0, skip_trx_check=True)


### PR DESCRIPTION
### Description
This PR proposes to add an API to control ISEE of citizens during tests.
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- add ISEE mock API
- refactor "onboard two times" test
<!--- Describe your changes in detail -->

### Motivation and context
With this change we set up a step to control users' ISEE in tests with onboarding criteria.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
