### PR TITLE
feat: [IDP-1620] Add suspension and readmission scenarios

### DIFF
--- a/api/idpay.py
+++ b/api/idpay.py
@@ -502,3 +502,16 @@ def put_citizen_suspension(selfcare_token: str,
         },
         timeout=settings.default_timeout
     )
+
+
+def put_citizen_readmission(selfcare_token: str,
+                            initiative_id: str,
+                            fiscal_code: str):
+    return requests.put(
+        f'{settings.base_path.IO}{settings.IDPAY.domain}/initiative/{initiative_id}/{settings.IDPAY.endpoints.initiatives.beneficiary.path}{settings.IDPAY.endpoints.initiatives.beneficiary.readmit}',
+        headers={
+            'Authorization': f'Bearer {selfcare_token}',
+            'Fiscal-Code': f'{fiscal_code}',
+        },
+        timeout=settings.default_timeout
+    )

--- a/api/idpay.py
+++ b/api/idpay.py
@@ -491,8 +491,14 @@ def delete_initiative(initiative_id: str):
         timeout=settings.default_timeout)
 
 
-def put_user_id_suspension(initiative_id: str,
-                           user_id: str):
+def put_user_id_suspension(selfcare_token: str,
+                           initiative_id: str,
+                           fiscal_code: str):
     return requests.put(
-        f'{settings.base_path.IDPAY.internal}{settings.IDPAY.endpoints.wallet.internal}{settings.IDPAY.domain}{settings.IDPAY.endpoints.wallet.path}/{initiative_id}/{user_id}/suspend',
-        timeout=settings.default_timeout)
+        f'{settings.base_path.IO}{settings.IDPAY.domain}/initiative/{initiative_id}/{settings.IDPAY.endpoints.initiatives.beneficiary.path}{settings.IDPAY.endpoints.initiatives.beneficiary.suspend}',
+        headers={
+            'Authorization': f'Bearer {selfcare_token}',
+            'Fiscal-Code': f'{fiscal_code}',
+        },
+        timeout=settings.default_timeout
+    )

--- a/api/idpay.py
+++ b/api/idpay.py
@@ -491,7 +491,7 @@ def delete_initiative(initiative_id: str):
         timeout=settings.default_timeout)
 
 
-def put_user_id_suspension(selfcare_token: str,
+def put_citizen_suspension(selfcare_token: str,
                            initiative_id: str,
                            fiscal_code: str):
     return requests.put(

--- a/api/idpay.py
+++ b/api/idpay.py
@@ -489,3 +489,10 @@ def delete_initiative(initiative_id: str):
     return requests.delete(
         f'{settings.base_path.IDPAY.internal}{settings.IDPAY.endpoints.initiatives.portal}{settings.IDPAY.domain}/initiative/{initiative_id}',
         timeout=settings.default_timeout)
+
+
+def put_user_id_suspension(initiative_id: str,
+                           user_id: str):
+    return requests.put(
+        f'{settings.base_path.IDPAY.internal}{settings.IDPAY.endpoints.wallet.internal}{settings.IDPAY.domain}{settings.IDPAY.endpoints.wallet.path}/{initiative_id}/{user_id}/suspend',
+        timeout=settings.default_timeout)

--- a/api/pdv.py
+++ b/api/pdv.py
@@ -1,0 +1,42 @@
+import requests
+
+from conf.configuration import secrets
+from conf.configuration import settings
+
+
+def get_pdv_token(fiscal_code: str):
+    """API to get Personal Data Vault token associated to the desired fiscal code.
+            :param fiscal_code: Fiscal code of interest.
+            :returns: the response of the call.
+            :rtype: requests.Response
+        """
+    return requests.put(
+        url=f'{settings.base_path.PDV}{settings.PDV.endpoints.tokenizer}',
+        headers={
+            'Content-Type': 'application/json',
+            'x-api-key': secrets.api_key.PDV
+        },
+        json={
+            'pii': fiscal_code
+        },
+        timeout=settings.default_timeout
+    )
+
+
+def detokenize_pdv_token(token: str):
+    """API to get fiscal code given a Personal Data Vault token.
+                :param token: Fiscal code of interest.
+                :returns: the response of the call.
+                :rtype: requests.Response
+            """
+    return requests.get(
+        url=f'{settings.base_path.PDV}{settings.PDV.endpoints.tokenizer}/{token}/pii',
+        headers={
+            'Content-Type': 'application/json',
+            'x-api-key': secrets.api_key.PDV
+        },
+        json={
+            'pii': token
+        },
+        timeout=settings.default_timeout
+    )

--- a/bdd/environment.py
+++ b/bdd/environment.py
@@ -15,16 +15,19 @@ def before_all(context):
 def before_feature(context, feature):
     """Create the feature's initiative if it has not been yet created for this run
     """
-    context.shared_data = {}
-    # Create the initiative given a proper first tag on feature file (if not created in this run)
-    context.curr_initiative_name = feature.tags[0]
+    created = False
+    # Create an initiative for each proper tag on feature file (if not created yet in this run)
+    for curr_initiative_name in feature.tags:
+        if curr_initiative_name in settings.initiatives:
+            if curr_initiative_name not in secrets.initiatives.keys():
+                secrets.initiatives[curr_initiative_name] = {}
+                secrets.initiatives[curr_initiative_name]['id'] = create_initiative(
+                    initiative_name_in_settings=curr_initiative_name)
+                print(
+                    f'Created initiative {secrets.initiatives[curr_initiative_name]["id"]} ({curr_initiative_name})')
+                created = True
 
-    if context.curr_initiative_name not in secrets.initiatives.keys():
-        secrets.initiatives[context.curr_initiative_name] = {}
-        secrets.initiatives[context.curr_initiative_name]['id'] = create_initiative(
-            initiative_name_in_settings=context.curr_initiative_name)
-        print(
-            f'Created initiative {secrets.initiatives[context.curr_initiative_name]["id"]} ({context.curr_initiative_name})')
+    if created:
         time.sleep(settings.INITIATIVE_STARTUP_TIME_SECONDS)
 
 

--- a/bdd/features/pilot/pilot_cancellation.feature
+++ b/bdd/features/pilot/pilot_cancellation.feature
@@ -126,7 +126,7 @@ Feature: A transaction can be cancelled by the merchant
     And the merchant 1 cancels the transaction X
     And the transaction X is cancelled
     When the citizen A tries to pre-authorize the transaction X
-    Then the latest pre-authorization fails because the transaction no longer exists
+    Then the latest pre-authorization fails because the transaction cannot be found
 
   @MIL
   Scenario: Before pre-authorization, after a cancellation request the transaction, created through MIL, is cancelled and cannot be pre-authorized
@@ -134,7 +134,7 @@ Feature: A transaction can be cancelled by the merchant
     And the merchant 1 cancels the transaction X through MIL
     And the transaction X is cancelled
     When the citizen A tries to pre-authorize the transaction X
-    Then the latest pre-authorization fails because the transaction no longer exists
+    Then the latest pre-authorization fails because the transaction cannot be found
 
   Scenario: Transaction cancelled before the citizen’s authorization
     Given the merchant 1 generates the transaction X of amount 15000 cents

--- a/bdd/features/pilot/pilot_readmission.feature
+++ b/bdd/features/pilot/pilot_readmission.feature
@@ -1,0 +1,38 @@
+@Scontoditipo1
+@Scontoditipo1_not_started
+@readmission
+Feature: A citizen can be suspended from an initiative by the promoting institution
+
+  Scenario: The Institution tries to readmit a suspended citizen during the fruition period and receives an OK result
+    Given the initiative is "Scontoditipo1"
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the institution suspends correctly the citizen A
+    When the institution tries to readmit the citizen A
+    Then the citizen A is readmitted
+
+  Scenario: The Institution tries to readmit a suspended citizen during the subscription period and receives an OK result
+    Given the initiative is "Scontoditipo1_not_started"
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the institution suspends correctly the citizen A
+    When the institution tries to readmit the citizen A
+    Then the citizen A is readmitted
+
+  Scenario: The Institution tries to readmit a citizen not registered in the initiative and receives a KO
+    Given the initiative is "Scontoditipo1"
+    And the citizen A is 25 years old at most
+    When the institution tries to readmit the citizen A
+    Then the latest readmission fails not finding the citizen
+
+  Scenario: A readmitted citizen confirms successfully a transaction and is rewarded
+    Given the initiative is "Scontoditipo1"
+    And the random merchant 1 is onboard
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the institution suspends correctly the citizen A
+    And the institution readmits correctly the citizen A
+    And the merchant 1 generates the transaction X of amount 2001 cents
+    When the citizen A confirms the transaction X
+    Then the transaction X is authorized
+    And the citizen A is rewarded with 20.01 euros

--- a/bdd/features/pilot/pilot_suspension.feature
+++ b/bdd/features/pilot/pilot_suspension.feature
@@ -1,0 +1,80 @@
+@Scontoditipo1
+@Scontoditipo1_not_started
+@Scontoditipo1_allocated
+@suspension
+Feature: A citizen can be suspended from an initiative by the promoting institution
+
+  Scenario: The Institution tries to suspend an onboard citizen during the fruition period and receives an OK result
+    Given the initiative is "Scontoditipo1"
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    When the institution suspends the citizen A
+    Then the citizen A is suspended
+
+  Scenario: The Institution tries to suspend an onboard citizen during the subscription period receives an OK result
+    Given the initiative is "Scontoditipo1_not_started"
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    When the institution suspends the citizen A
+    Then the citizen A is suspended
+
+  Scenario: The Institution tries to suspend a citizen not registered in the initiative and receives a KO
+    Given the initiative is "Scontoditipo1"
+    And the citizen A is 25 years old at most
+    When the institution tries to suspend the citizen A
+    Then the latest suspension fails not finding the citizen
+
+  Scenario: A suspended citizen who tries to onboard remains in the "suspended" state
+    Given the initiative is "Scontoditipo1"
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the institution suspends correctly the citizen A
+    When the citizen A tries to onboard
+    Then the citizen A is suspended
+
+  Scenario: A suspended citizen who tries to pre-authorise a trx receives a KO result
+    Given the initiative is "Scontoditipo1"
+    And the random merchant 1 is onboard
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the institution suspends correctly the citizen A
+    And the merchant 1 generates the transaction X of amount 20001 cents
+    When the citizen A tries to pre-authorize the transaction X
+    Then the latest pre-authorization fails because the user is suspended
+
+  Scenario: If a transaction is correctly authorized by the citizen, if the latter is suspended, the payment mandate is correctly generated
+    Given the initiative is "Scontoditipo1"
+    And the random merchant 1 is onboard
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 1001 cents
+    And the citizen A confirms the transaction X
+    And the institution suspends correctly the citizen A
+    When the batch process confirms the transaction X
+    Then the citizen A is rewarded with 10.01 euros
+    And the merchant 1 is refunded 10.01 euros
+
+  @skip
+  Scenario: In the face of a trx made by a citizen who is subsequently suspended, the Institution will receive a refund
+    Given the initiative is "Scontoditipo1"
+    And the random merchant 1 is onboard
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 1001 cents
+    And the citizen A confirms the transaction X
+    And the institution suspends correctly the citizen A
+    When the batch process confirms the transaction X
+    Then the citizen A is rewarded with 10.01 euros
+    And the merchant 1 is refunded 10.01 euros
+    And the return flow is ok
+
+  Scenario: Suspending a citizen does not free up the budget of an initiative with a fully allocated budget
+    Given the initiative is "Scontoditipo1_allocated"
+    And the initiative's budget is almost allocated
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the citizen B is 25 years old at most
+    And the institution suspends correctly the citizen A
+    When the citizen B tries to accept terms and condition
+    Then the latest accept terms and condition failed for budget terminated
+    And the onboard of B is KO

--- a/bdd/features/pilot/pilot_suspension.feature
+++ b/bdd/features/pilot/pilot_suspension.feature
@@ -66,7 +66,7 @@ Feature: A citizen can be suspended from an initiative by the promoting institut
     And the merchant 1 is refunded 10.01 euros
 
   @skip
-  Scenario: In the face of a trx made by a citizen who is subsequently suspended, the Institution will receive a refund
+  Scenario: If a transaction is confirmed by the citizen is subsequently suspended, the Institution will receive a refund
     Given the initiative is "Scontoditipo1"
     And the random merchant 1 is onboard
     And the citizen A is 25 years old at most

--- a/bdd/features/pilot/pilot_suspension.feature
+++ b/bdd/features/pilot/pilot_suspension.feature
@@ -32,7 +32,7 @@ Feature: A citizen can be suspended from an initiative by the promoting institut
     When the citizen A tries to onboard
     Then the citizen A is suspended
 
-  Scenario: A suspended citizen who tries to pre-authorise a trx receives a KO result
+  Scenario: A suspended citizen who tries to pre-authorize a transaction receives a KO result
     Given the initiative is "Scontoditipo1"
     And the random merchant 1 is onboard
     And the citizen A is 25 years old at most
@@ -41,6 +41,17 @@ Feature: A citizen can be suspended from an initiative by the promoting institut
     And the merchant 1 generates the transaction X of amount 20001 cents
     When the citizen A tries to pre-authorize the transaction X
     Then the latest pre-authorization fails because the user is suspended
+
+  Scenario: A citizen who tries to authorize a transaction, being suspended after pre-authorization, receives a KO result
+    Given the initiative is "Scontoditipo1"
+    And the random merchant 1 is onboard
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 20001 cents
+    And the citizen A pre-authorizes the transaction X
+    And the institution suspends correctly the citizen A
+    When the citizen A tries to authorize the transaction X
+    Then the latest authorization fails because the user is suspended
 
   Scenario: If a transaction is correctly authorized by the citizen, if the latter is suspended, the payment mandate is correctly generated
     Given the initiative is "Scontoditipo1"

--- a/bdd/features/pilot/pilot_suspension.feature
+++ b/bdd/features/pilot/pilot_suspension.feature
@@ -66,7 +66,7 @@ Feature: A citizen can be suspended from an initiative by the promoting institut
     And the merchant 1 is refunded 10.01 euros
 
   @skip
-  Scenario: If a transaction is confirmed by the citizen is subsequently suspended, the Institution will receive a refund
+  Scenario: If a transaction is confirmed by the citizen and it is subsequently suspended, the Institution will receive a refund
     Given the initiative is "Scontoditipo1"
     And the random merchant 1 is onboard
     And the citizen A is 25 years old at most

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -145,43 +145,43 @@ Feature: A transaction is generated, authorized and confirmed
     Then the transaction X is authorized
     And the citizen A is rewarded with 300 euros
 
-  Scenario: The transaction is not authorized for onboarding citizen KO
+  Scenario: The transaction is not authorized for a citizen which got KO during onboarding
     Given the random merchant 1 is onboard
     And the citizen A is not onboard
     And the merchant 1 generates the transaction X of amount 30000 cents
-    When the citizen A tries to confirm the transaction X
-    Then the transaction X is not authorized
+    When the citizen A tries to pre-authorize the transaction X
+    Then the latest pre-authorization fails because the citizen is not onboard
 
   @MIL
   Scenario: The transaction, created through MIL, is not authorized for onboarding citizen KO
     Given the random merchant 1 is onboard
     And the citizen A is not onboard
     And the merchant 1 generates the transaction X of amount 30000 cents through MIL
-    When the citizen A tries to confirm the transaction X
-    Then the transaction X is not authorized
+    When the citizen A tries to pre-authorize the transaction X
+    Then the latest pre-authorization fails because the citizen is not onboard
 
   Scenario: The transaction is not authorized for ever registered citizen
     Given the random merchant 1 is onboard
     And the merchant 1 generates the transaction X of amount 30000 cents
-    When the citizen A tries to confirm the transaction X
-    Then the transaction X is not authorized
+    When the citizen A tries to pre-authorize the transaction X
+    Then the latest pre-authorization fails because the citizen is not onboard
 
   @MIL
   Scenario: The transaction, created through MIL, is not authorized for ever registered citizen
     Given the random merchant 1 is onboard
     And the merchant 1 generates the transaction X of amount 30000 cents through MIL
-    When the citizen A tries to confirm the transaction X
-    Then the transaction X is not authorized
+    When the citizen A tries to pre-authorize the transaction X
+    Then the latest pre-authorization fails because the citizen is not onboard
 
-  Scenario: The transaction cannot be authorized again if an ever registered citizen tried to authorize it
+  Scenario: The transaction can still be authorized if an ever registered citizen tried to authorize it
     Given the random merchant 1 is onboard
     And the citizen A is not onboard
     And the citizen B is 20 years old at most
     And the citizen B is onboard
     And the merchant 1 generates the transaction X of amount 30000 cents
     And the citizen A tries to pre-authorize the transaction X
-    When the citizen B tries to confirm the transaction X
-    Then the transaction X is already assigned
+    When the citizen B confirms the transaction X
+    Then the transaction X is authorized
 
   @MIL
   Scenario: The transaction, created through MIL, cannot be authorized again if an ever registered citizen tried to authorize it

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -499,3 +499,10 @@ Feature: A transaction is generated, authorized and confirmed
     And the citizen A pre-authorizes the transaction X
     When the citizen A pre-authorizes the transaction X
     Then the transaction X is identified
+
+  Scenario: Citizen fails pre-authorizing a non-existing transaction code (chosen at random)
+    Given the random merchant 1 is onboard
+    And the citizen A is onboard
+    And the transaction X does not exists
+    When the citizen A tries to pre-authorize the transaction X
+    Then the latest pre-authorization fails because the transaction cannot be found

--- a/bdd/features/tipo6/_cancellation.feature
+++ b/bdd/features/tipo6/_cancellation.feature
@@ -25,14 +25,14 @@ Feature: A transaction can be cancelled by the merchant 1
     And the merchant 1 cancels the transaction X
     And the transaction X is cancelled
     When the citizen A tries to authorize the transaction X
-    Then the latest authorization fails because the transaction no longer exists
+    Then the latest authorization fails because the transaction cannot be found
 
   Scenario: After a cancellation by merchant a transaction before pre-authorization, if the citizen tries to confirm receives error
     Given the merchant 1 generates the transaction X of amount 1000 cents
     And the merchant 1 cancels the transaction X
     And the transaction X is cancelled
     When the citizen A tries to pre-authorize the transaction X
-    Then the latest pre-authorization fails because the transaction no longer exists
+    Then the latest pre-authorization fails because the transaction cannot be found
 
   Scenario: After a cancellation by merchant of a transaction before authorization, if the citizen tries to cancel receives error
     Given the merchant 1 generates the transaction X of amount 1000 cents
@@ -40,7 +40,7 @@ Feature: A transaction can be cancelled by the merchant 1
     And the merchant 1 cancels the transaction X
     And the transaction X is cancelled
     When the citizen A tries to cancel the transaction X
-    Then the latest cancellation by citizen fails because the transaction no longer exists
+    Then the latest cancellation by citizen fails because the transaction cannot be found
 
   @skip
   Scenario: After 7 days of authorization, the merchant cannot cancel the transaction
@@ -55,7 +55,7 @@ Feature: A transaction can be cancelled by the merchant 1
     And the merchant 1 cancels the transaction X
     And the transaction X is cancelled
     When the citizen A tries to pre-authorize the transaction X
-    Then the latest pre-authorization fails because the transaction no longer exists
+    Then the latest pre-authorization fails because the transaction cannot be found
 
   Scenario: If a citizen pre-authorizes and then cancels the transaction, another citizen receives an error if he tries to pre-authorize
     Given the citizen B is 20 years old at most

--- a/bdd/features/tipo6/_refund.feature
+++ b/bdd/features/tipo6/_refund.feature
@@ -4,7 +4,7 @@ Feature: A merchant gets refunded if a transaction is discounted
 
   Background:
     Given the initiative is "Scontoditipo6"
-    And the merchant 1 is qualified
+    And the random merchant 1 is onboard
     And the citizen A is 20 years old at most
     And the citizen A is onboarded
 

--- a/bdd/steps/dataset_steps.py
+++ b/bdd/steps/dataset_steps.py
@@ -1,5 +1,6 @@
 import datetime
 import random
+import uuid
 
 import pytz
 from behave import given
@@ -54,6 +55,11 @@ def step_citizen_fc_from_name_age_and_precision(context, citizen_name: str, age:
 def step_set_citizen_isee(context, citizen_name: str, isee: int):
     res = control_mocked_isee(fc=context.citizens_fc[citizen_name], isee=int(isee))
     assert res.status_code == 201
+
+
+@given('the transaction {trx_name} does not exists')
+def step_trx_before_fruition_period(context, trx_name):
+    context.transactions[trx_name] = {'trxCode': str(uuid.uuid4())[:8]}
 
 
 @given('the transaction is created before fruition period')

--- a/bdd/steps/dataset_steps.py
+++ b/bdd/steps/dataset_steps.py
@@ -20,6 +20,7 @@ def step_citizen_fc_exact_or_random(context, citizen_fc):
 
     return citizen_fc
 
+
 @given('the citizen {citizen_name} is {age} years old {precision}')
 def step_citizen_fc_from_name_age_and_precision(context, citizen_name: str, age: int, precision: str):
     citizen_fc = fake_fc(age=age)

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -377,6 +377,8 @@ def step_citizen_only_pre_authorize_transaction(context, citizen_name, trx_name)
     trx_code = context.transactions[trx_name]['trxCode']
 
     context.latest_authorization_response = put_authorize_payment(trx_code, token_io)
+    context.latest_transaction_name = trx_name
+    context.associated_citizen[trx_name] = context.citizens_fc[citizen_name]
 
 
 @given('the latest pre-authorization fails')
@@ -396,6 +398,15 @@ def step_check_latest_pre_authorization_failed_user_suspended(context):
     assert context.latest_pre_authorization_response.status_code == 403
     assert context.latest_pre_authorization_response.json()['code'] == 'USER_SUSPENDED'
     assert context.latest_pre_authorization_response.json()[
+               'message'] == f'User {curr_tokenized_fc} has been suspended for initiative {context.initiative_id}'
+
+
+@then('the latest authorization fails because the user is suspended')
+def step_check_latest_pre_authorization_failed_user_suspended(context):
+    curr_tokenized_fc = tokenize_fc(context.associated_citizen[context.latest_transaction_name])
+    assert context.latest_authorization_response.status_code == 403
+    assert context.latest_authorization_response.json()['code'] == 'USER_SUSPENDED'
+    assert context.latest_authorization_response.json()[
                'message'] == f'User {curr_tokenized_fc} has been suspended for initiative {context.initiative_id}'
 
 

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -352,6 +352,9 @@ def step_citizen_only_pre_authorize_transaction(context, citizen_name, trx_name)
     res = put_pre_authorize_payment(trx_code, token_io)
 
     context.latest_pre_authorization_response = res
+    context.latest_transaction_name = trx_name
+
+    context.associated_citizen[trx_name] = context.citizens_fc[citizen_name]
 
 
 @when('the citizen {citizen_name} pre-authorizes the transaction {trx_name}')

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -404,6 +404,15 @@ def step_check_latest_pre_authorization_failed_user_suspended(context):
                'message'] == f'User {curr_tokenized_fc} has been suspended for initiative {context.initiative_id}'
 
 
+@then('the latest pre-authorization fails because the citizen is not onboard')
+def step_check_latest_pre_authorization_failed_citizen_not_onboard(context):
+    curr_tokenized_fc = tokenize_fc(context.associated_citizen[context.latest_transaction_name])
+    assert context.latest_pre_authorization_response.status_code == 404
+    assert context.latest_pre_authorization_response.json()['code'] == 'WALLET'
+    assert context.latest_pre_authorization_response.json()[
+               'message'] == f'A wallet related to the user {curr_tokenized_fc} with initiativeId {context.initiative_id} was not found.'
+
+
 @then('the latest authorization fails because the user is suspended')
 def step_check_latest_pre_authorization_failed_user_suspended(context):
     curr_tokenized_fc = tokenize_fc(context.associated_citizen[context.latest_transaction_name])

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -387,9 +387,12 @@ def step_check_latest_pre_authorization_failed(context):
     assert context.latest_pre_authorization_response.status_code == 403
 
 
-@then('the latest pre-authorization fails because the transaction no longer exists')
+@then('the latest pre-authorization fails because the transaction cannot be found')
 def step_check_latest_pre_authorization_failed_not_found(context):
     assert context.latest_pre_authorization_response.status_code == 404
+    assert context.latest_pre_authorization_response.json()['code'] == 'PAYMENT_NOT_FOUND_EXPIRED'
+    assert context.latest_pre_authorization_response.json()['message'].startswith(
+        'Cannot find transaction with trxCode ')
 
 
 @then('the latest pre-authorization fails because the user is suspended')
@@ -410,7 +413,7 @@ def step_check_latest_pre_authorization_failed_user_suspended(context):
                'message'] == f'User {curr_tokenized_fc} has been suspended for initiative {context.initiative_id}'
 
 
-@then('the latest authorization fails because the transaction no longer exists')
+@then('the latest authorization fails because the transaction cannot be found')
 def step_check_latest_authorization_failed(context):
     assert context.latest_authorization_response.status_code == 404
 
@@ -420,7 +423,7 @@ def step_check_latest_cancellation_failed(context):
     assert context.latest_cancellation_response.status_code == 429
 
 
-@then('the latest cancellation by citizen fails because the transaction no longer exists')
+@then('the latest cancellation by citizen fails because the transaction cannot be found')
 def step_check_latest_cancellation_by_citizen_failed(context):
     assert context.latest_citizen_cancellation_response.status_code == 404
 

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -19,6 +19,7 @@ from conf.configuration import settings
 from util.utility import check_unprocessed_transactions
 from util.utility import get_io_token
 from util.utility import retry_timeline
+from util.utility import tokenize_fc
 
 default_merchant_name = '1'
 timeline_operations = settings.IDPAY.endpoints.timeline.operations
@@ -387,6 +388,15 @@ def step_check_latest_pre_authorization_failed(context):
 @then('the latest pre-authorization fails because the transaction no longer exists')
 def step_check_latest_pre_authorization_failed_not_found(context):
     assert context.latest_pre_authorization_response.status_code == 404
+
+
+@then('the latest pre-authorization fails because the user is suspended')
+def step_check_latest_pre_authorization_failed_user_suspended(context):
+    curr_tokenized_fc = tokenize_fc(context.associated_citizen[context.latest_transaction_name])
+    assert context.latest_pre_authorization_response.status_code == 403
+    assert context.latest_pre_authorization_response.json()['code'] == 'USER_SUSPENDED'
+    assert context.latest_pre_authorization_response.json()[
+               'message'] == f'User {curr_tokenized_fc} has been suspended for initiative {context.initiative_id}'
 
 
 @then('the latest authorization fails because the transaction no longer exists')

--- a/bdd/steps/initiative_steps.py
+++ b/bdd/steps/initiative_steps.py
@@ -1,6 +1,5 @@
 import datetime
 import math
-import time
 
 import pytz
 from behave import given
@@ -8,11 +7,9 @@ from behave import then
 
 from api.idpay import get_initiative_statistics
 from bdd.steps.dataset_steps import step_citizen_fc_exact_or_random
-from bdd.steps.onboarding_steps import step_citizen_tries_to_onboard
 from bdd.steps.onboarding_steps import step_named_citizen_onboard
 from conf.configuration import secrets
 from conf.configuration import settings
-from util.dataset_utility import fake_fc
 from util.utility import check_statistics
 
 
@@ -63,11 +60,13 @@ def base_context_initialization(context):
     context.associated_merchant = {}
 
 
-@given("the initiative's budget is totally allocated")
-def step_check_initiative_budget_allocated(context):
+@given("the initiative's budget is {precision} allocated")
+def step_allocate_initiative_budget(context, precision):
     i = 0
-
     allowable_citizens = math.floor(context.total_budget / context.budget_per_citizen)
+
+    if precision == 'almost':
+        allowable_citizens -= 1
 
     context.base_statistics = get_initiative_statistics(organization_id=secrets.organization_id,
                                                         initiative_id=context.initiative_id).json()

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -21,6 +21,7 @@ from util.utility import get_selfcare_token
 from util.utility import iban_enroll
 from util.utility import onboard_random_merchant
 from util.utility import retry_io_onboarding
+from util.utility import retry_merchant_statistics
 from util.utility import retry_timeline
 from util.utility import retry_wallet
 
@@ -216,9 +217,10 @@ def step_merchant_qualified(context, merchant_name):
     curr_merchant_info = onboard_random_merchant(initiative_id=context.initiative_id,
                                                  institution_selfcare_token=institution_token)
     context.merchants[merchant_name] = curr_merchant_info
-    context.base_merchants_statistics[merchant_name] = get_initiative_statistics_merchant_portal(
+
+    context.base_merchants_statistics[merchant_name] = retry_merchant_statistics(
         merchant_id=curr_merchant_info['id'],
-        initiative_id=context.initiative_id).json()
+        initiative_id=context.initiative_id)
 
 
 @given('the citizen {citizen_name} enrolls a random card')

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -42,6 +42,11 @@ def step_named_citizen_suspension(context, citizen_name):
     step_check_onboarding_status(context=context, citizen_name=citizen_name, status='SUSPENDED')
 
 
+@then('the citizen {citizen_name} is readmitted')
+def step_named_citizen_suspension(context, citizen_name):
+    step_check_onboarding_status(context=context, citizen_name=citizen_name, status='READMITTED')
+
+
 @given('the citizen {citizen_name} is not onboard')
 def step_citizen_not_onboard(context, citizen_name):
     step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
@@ -112,6 +117,19 @@ def step_check_onboarding_status(context, citizen_name, status):
         retry_timeline(expected=timeline_operations.suspended, request=timeline, num_required=1, token=token_io,
                        initiative_id=context.initiative_id, field='operationType', tries=10, delay=3,
                        message='Not suspended')
+        curr_onboarded_citizen_count_increment = 0
+
+    elif status == 'READMITTED':
+        expected_status = 'ONBOARDING_OK'
+        retry_io_onboarding(expected=expected_status, request=status_onboarding, token=token_io,
+                            initiative_id=context.initiative_id, field='status', tries=50, delay=0.1,
+                            message=f'Citizen onboard not {status}'
+                            )
+        retry_wallet(expected=wallet_statuses.refundable, request=wallet, token=token_io,
+                     initiative_id=context.initiative_id, field='status', tries=3, delay=3)
+        retry_timeline(expected=timeline_operations.readmitted, request=timeline, num_required=1, token=token_io,
+                       initiative_id=context.initiative_id, field='operationType', tries=10, delay=3,
+                       message='Not readmitted')
         curr_onboarded_citizen_count_increment = 0
 
     elif status == 'OK':

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -37,6 +37,11 @@ def step_named_citizen_onboard(context, citizen_name):
     step_check_onboarding_status(context=context, citizen_name=citizen_name, status='OK')
 
 
+@then('the citizen {citizen_name} is suspended')
+def step_named_citizen_suspension(context, citizen_name):
+    step_check_onboarding_status(context=context, citizen_name=citizen_name, status='SUSPENDED')
+
+
 @given('the citizen {citizen_name} is not onboard')
 def step_citizen_not_onboard(context, citizen_name):
     step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
@@ -78,18 +83,17 @@ def step_citizen_accept_terms_and_condition(context, citizen_name):
 
 @then('the onboard of {citizen_name} is {status}')
 def step_check_onboarding_status(context, citizen_name, status):
+    status = status.upper()
     token_io = get_io_token(context.citizens_fc[citizen_name])
     res = status_onboarding(token_io, context.initiative_id)
     assert res.status_code == 200
 
-    expected_status = f'ONBOARDING_{status}'
-
-    retry_io_onboarding(expected=expected_status, request=status_onboarding, token=token_io,
-                        initiative_id=context.initiative_id, field='status', tries=50, delay=0.1,
-                        message=f'Citizen onboard not {status}'
-                        )
-
     if status == 'KO':
+        expected_status = f'ONBOARDING_{status}'
+        retry_io_onboarding(expected=expected_status, request=status_onboarding, token=token_io,
+                            initiative_id=context.initiative_id, field='status', tries=50, delay=0.1,
+                            message=f'Citizen onboard not {status}'
+                            )
         curr_onboarded_citizen_count_increment = 0
         res = wallet(initiative_id=context.initiative_id, token=token_io)
         assert res.status_code == 404
@@ -97,7 +101,26 @@ def step_check_onboarding_status(context, citizen_name, status):
         assert res.status_code == 200
         assert not res.json()['operationList']
 
-    else:
+    elif status == 'SUSPENDED':
+        expected_status = status
+        retry_io_onboarding(expected=expected_status, request=status_onboarding, token=token_io,
+                            initiative_id=context.initiative_id, field='status', tries=50, delay=0.1,
+                            message=f'Citizen onboard not {status}'
+                            )
+        retry_wallet(expected=wallet_statuses.suspended, request=wallet, token=token_io,
+                     initiative_id=context.initiative_id, field='status', tries=3, delay=3)
+        retry_timeline(expected=timeline_operations.suspended, request=timeline, num_required=1, token=token_io,
+                       initiative_id=context.initiative_id, field='operationType', tries=10, delay=3,
+                       message='Not suspended')
+        curr_onboarded_citizen_count_increment = 0
+
+    elif status == 'OK':
+        expected_status = f'ONBOARDING_{status}'
+
+        retry_io_onboarding(expected=expected_status, request=status_onboarding, token=token_io,
+                            initiative_id=context.initiative_id, field='status', tries=50, delay=0.1,
+                            message=f'Citizen onboard not {status}'
+                            )
         retry_wallet(expected=wallet_statuses.refundable, request=wallet, token=token_io,
                      initiative_id=context.initiative_id, field='status', tries=3, delay=3)
         retry_timeline(expected=timeline_operations.onboarding, request=timeline, num_required=1, token=token_io,
@@ -108,6 +131,9 @@ def step_check_onboarding_status(context, citizen_name, status):
                                token=token_io,
                                initiative_id=context.initiative_id)
         curr_onboarded_citizen_count_increment = 1
+
+    else:
+        assert False, 'Unexpected status'
 
     check_statistics(organization_id=context.organization_id,
                      initiative_id=context.initiative_id,

--- a/bdd/steps/suspension_readmission_steps.py
+++ b/bdd/steps/suspension_readmission_steps.py
@@ -2,10 +2,12 @@ from behave import given
 from behave import then
 from behave import when
 
+from api.idpay import put_citizen_readmission
 from api.idpay import put_citizen_suspension
 from bdd.steps.onboarding_steps import step_check_onboarding_status
 from conf.configuration import secrets
 from util.utility import get_selfcare_token
+from util.utility import readmit_citizen_to_initiative
 from util.utility import suspend_citizen_from_initiative
 
 
@@ -34,4 +36,27 @@ def step_check_latest_suspension(context):
     assert context.latest_suspension_response.status_code == 404
     assert context.latest_suspension_response.json()['code'] == 404
     assert context.latest_suspension_response.json()[
+               'message'] == 'The requested initiative is not active for the current user!'
+
+
+@when('the institution tries to readmit the citizen {citizen_name}')
+def step_institution_tries_citizen_readmission(context, citizen_name):
+    institution_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
+    res = put_citizen_readmission(selfcare_token=institution_token, initiative_id=context.initiative_id,
+                                  fiscal_code=context.citizens_fc[citizen_name])
+    context.latest_readmission_response = res
+
+
+@given('the institution readmits correctly the citizen {citizen_name}')
+@when('the institution readmits correctly the citizen {citizen_name}')
+def step_institution_suspends_correctly_citizen(context, citizen_name):
+    readmit_citizen_to_initiative(initiative_id=context.initiative_id, fiscal_code=context.citizens_fc[citizen_name])
+    step_check_onboarding_status(context=context, citizen_name=citizen_name, status='READMITTED')
+
+
+@then('the latest readmission fails not finding the citizen')
+def step_check_latest_readmission(context):
+    assert context.latest_readmission_response.status_code == 404
+    assert context.latest_readmission_response.json()['code'] == 404
+    assert context.latest_readmission_response.json()[
                'message'] == 'The requested initiative is not active for the current user!'

--- a/bdd/steps/suspension_steps.py
+++ b/bdd/steps/suspension_steps.py
@@ -2,7 +2,7 @@ from behave import given
 from behave import then
 from behave import when
 
-from api.idpay import put_user_id_suspension
+from api.idpay import put_citizen_suspension
 from bdd.steps.onboarding_steps import step_check_onboarding_status
 from conf.configuration import secrets
 from util.utility import get_selfcare_token
@@ -17,8 +17,8 @@ def step_institution_suspends_citizen(context, citizen_name):
 @when('the institution tries to suspend the citizen {citizen_name}')
 def step_institution_tries_citizen_suspension(context, citizen_name):
     institution_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
-    res = put_user_id_suspension(initiative_id=context.initiative_id, fiscal_code=context.citizens_fc[citizen_name],
-                                 selfcare_token=institution_token)
+    res = put_citizen_suspension(selfcare_token=institution_token, initiative_id=context.initiative_id,
+                                 fiscal_code=context.citizens_fc[citizen_name])
     context.latest_suspension_response = res
 
 

--- a/bdd/steps/suspension_steps.py
+++ b/bdd/steps/suspension_steps.py
@@ -4,8 +4,9 @@ from behave import when
 
 from api.idpay import put_user_id_suspension
 from bdd.steps.onboarding_steps import step_check_onboarding_status
+from conf.configuration import secrets
+from util.utility import get_selfcare_token
 from util.utility import suspend_citizen_from_initiative
-from util.utility import tokenize_fc
 
 
 @when('the institution suspends the citizen {citizen_name}')
@@ -15,8 +16,9 @@ def step_institution_suspends_citizen(context, citizen_name):
 
 @when('the institution tries to suspend the citizen {citizen_name}')
 def step_institution_tries_citizen_suspension(context, citizen_name):
-    token = tokenize_fc(fiscal_code=context.citizens_fc[citizen_name])
-    res = put_user_id_suspension(initiative_id=context.initiative_id, user_id=token)
+    institution_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
+    res = put_user_id_suspension(initiative_id=context.initiative_id, fiscal_code=context.citizens_fc[citizen_name],
+                                 selfcare_token=institution_token)
     context.latest_suspension_response = res
 
 

--- a/bdd/steps/suspension_steps.py
+++ b/bdd/steps/suspension_steps.py
@@ -1,0 +1,35 @@
+from behave import given
+from behave import then
+from behave import when
+
+from api.idpay import put_user_id_suspension
+from bdd.steps.onboarding_steps import step_check_onboarding_status
+from util.utility import suspend_citizen_from_initiative
+from util.utility import tokenize_fc
+
+
+@when('the institution suspends the citizen {citizen_name}')
+def step_institution_suspends_citizen(context, citizen_name):
+    suspend_citizen_from_initiative(initiative_id=context.initiative_id, fiscal_code=context.citizens_fc[citizen_name])
+
+
+@when('the institution tries to suspend the citizen {citizen_name}')
+def step_institution_tries_citizen_suspension(context, citizen_name):
+    token = tokenize_fc(fiscal_code=context.citizens_fc[citizen_name])
+    res = put_user_id_suspension(initiative_id=context.initiative_id, user_id=token)
+    context.latest_suspension_response = res
+
+
+@given('the institution suspends correctly the citizen {citizen_name}')
+@when('the institution suspends correctly the citizen {citizen_name}')
+def step_institution_suspends_correctly_citizen(context, citizen_name):
+    step_institution_suspends_citizen(context=context, citizen_name=citizen_name)
+    step_check_onboarding_status(context=context, citizen_name=citizen_name, status='SUSPENDED')
+
+
+@then('the latest suspension fails not finding the citizen')
+def step_check_latest_suspension(context):
+    assert context.latest_suspension_response.status_code == 404
+    assert context.latest_suspension_response.json()['code'] == 404
+    assert context.latest_suspension_response.json()[
+               'message'] == 'The requested initiative is not active for the current user!'

--- a/conf/.secrets_template.yaml
+++ b/conf/.secrets_template.yaml
@@ -7,6 +7,7 @@ uat:
     RTD_API_Product: <API_KEY_RTD_UAT>
     RTD_Mock_API_Product: <API_KEY_RTD_MOCK_UAT>
     IDPAY_MIL_PRODUCT: <API_KEY_IDPAY_MIL_PRODUCT>
+    PDV: <API_KEY_PDV>
   initiatives:
     not_started:
       id: <NOT_STARTED_ID>

--- a/settings.yaml
+++ b/settings.yaml
@@ -47,6 +47,7 @@ IDPAY:
         not_refundable_only_iban: 'NOT_REFUNDABLE_ONLY_IBAN'
         refundable: 'REFUNDABLE'
         unsubscribed: 'UNSUBSCRIBED'
+        suspended: 'SUSPENDED'
     timeline:
       path: '/timeline'
       operations:
@@ -56,6 +57,7 @@ IDPAY:
         delete_instrument: 'DELETE_INSTRUMENT'
         transaction: 'TRANSACTION'
         reversal: 'REVERSAL'
+        suspended: 'SUSPENDED'
     rewards:
       path: '/idpayrewardnotification/idpay'
       force_reward: '/reward/notification/exports/start?notificationDateToSearch='

--- a/settings.yaml
+++ b/settings.yaml
@@ -81,6 +81,10 @@ IDPAY:
       isee: '/mock/citizen/isee'
     initiatives:
       portal: '/idpayportalwelfarebackendinitiative'
+      beneficiary:
+        path: '/beneficiary'
+        suspend: '/suspend'
+        readmit: '/readmit'
   acquirer_id: 'PAGOPA'
 RTD:
   domain: "/rtd"

--- a/settings.yaml
+++ b/settings.yaml
@@ -48,6 +48,7 @@ IDPAY:
         refundable: 'REFUNDABLE'
         unsubscribed: 'UNSUBSCRIBED'
         suspended: 'SUSPENDED'
+        readmitted: 'READMITTED'
     timeline:
       path: '/timeline'
       operations:
@@ -58,6 +59,7 @@ IDPAY:
         transaction: 'TRANSACTION'
         reversal: 'REVERSAL'
         suspended: 'SUSPENDED'
+        readmitted: 'READMITTED'
     rewards:
       path: '/idpayrewardnotification/idpay'
       force_reward: '/reward/notification/exports/start?notificationDateToSearch='

--- a/settings.yaml
+++ b/settings.yaml
@@ -13,6 +13,7 @@ base_path:
   RTD: "https://api.uat.cstar.pagopa.it"
   IDPAY:
     internal: "https://uat01.idpay.internal.uat.cstar.pagopa.it"
+  PDV: "https://api.uat.tokenizer.pdv.pagopa.it"
 IDPAY:
   domain: "/idpay"
   MIL:
@@ -36,6 +37,7 @@ IDPAY:
       unsubscribed_message: 'Unsubscribed to initiative'
       unsubscribed_error_details: 'GENERIC_ERROR'
     wallet:
+      internal: '/idpaywallet'
       path: '/wallet'
       end_path: '/instruments'
       unsubscribe: '/unsubscribe'
@@ -93,6 +95,9 @@ RTD:
     mock_io:
       login: "/mock-io/login"
       user: "/mock-io/user"
+PDV:
+  endpoints:
+    tokenizer: '/tokenizer/v1/tokens'
 initiatives:
   not_started:
     message: 'The initiative has not yet begun'

--- a/settings.yaml
+++ b/settings.yaml
@@ -174,6 +174,87 @@ initiatives:
       refund:
         timeParameter:
           timeType: 'DAILY'
+  Scontoditipo1_not_started:
+    id: 'PILOT_NOT_STARTED'
+    cashback_percentage: 100
+    budget_per_citizen: 300
+    min_age: 18
+    max_age: 35
+    fruition_start: '2023-05-22T00:00:00.000+02:00'
+    fruition_end: '2024-05-22T23:59:59.000+02:00'
+    creation_payloads:
+      general:
+        budget: 999999999
+        beneficiaryBudget: 300
+        beneficiaryType: 'PF'
+        beneficiaryKnown: false
+        rankingEnabled: false
+        rankingStartDate: 'today'
+        rankingEndDate: 'tomorrow'
+        startDate: 'future'
+        endDate: 'future_tomorrow'
+        descriptionMap:
+          it: 'Iniziativa di test Sconto tipo 1 - not started'
+      beneficiary:
+        automatedCriteria:
+          - authority: 'AGID'
+            code: 'BIRTHDATE'
+            field: 'age'
+            operator: 'BTW_CLOSED'
+            value: '18'
+            value2: '35'
+        selfDeclarationCriteria:
+          - _type: 'boolean'
+            description: '1'
+            value: true
+            code: '1'
+      reward:
+        initiativeRewardType: 'DISCOUNT'
+        rewardRule:
+          _type: 'rewardValue'
+          rewardValue: 100
+          rewardValueType: 'PERCENTAGE'
+        trxRule: { }
+      refund:
+        timeParameter:
+          timeType: 'DAILY'
+  Scontoditipo1_allocated:
+    id: 'PILOT_ALLOCATED'
+    cashback_percentage: 100
+    budget_per_citizen: 200000
+    total_budget: 1000000
+    min_age: 18
+    max_age: 35
+    fruition_start: '2023-05-22T00:00:00.000+02:00'
+    fruition_end: '2024-05-22T23:59:59.000+02:00'
+    creation_payloads:
+      general:
+        budget: 1000000
+        beneficiaryBudget: 200000
+        beneficiaryType: 'PF'
+        beneficiaryKnown: false
+        rankingEnabled: false
+        startDate: 'today'
+        endDate: 'future'
+        descriptionMap:
+          it: 'Iniziativa di test Sconto tipo 1 - allocated'
+      beneficiary:
+        automatedCriteria: [ ]
+        selfDeclarationCriteria:
+          - _type: 'boolean'
+            description: '1'
+            value: true
+            code: '1'
+      reward:
+        initiativeRewardType: 'DISCOUNT'
+        rewardRule:
+          _type: 'rewardValue'
+          rewardValue: 100
+          rewardValueType: 'PERCENTAGE'
+        trxRule: { }
+      refund:
+        timeParameter:
+          timeType: 'DAILY'
   Scontoditipo6:
     id: 'SCONTOTIPO6'
     cashback_percentage: 87.12

--- a/util/utility.py
+++ b/util/utility.py
@@ -18,12 +18,13 @@ from api.idpay import get_reward_content
 from api.idpay import obtain_selfcare_test_token
 from api.idpay import post_initiative_info
 from api.idpay import publish_approved_initiative
+from api.idpay import put_citizen_readmission
+from api.idpay import put_citizen_suspension
 from api.idpay import put_initiative_approval
 from api.idpay import put_initiative_beneficiary_info
 from api.idpay import put_initiative_general_info
 from api.idpay import put_initiative_refund_info
 from api.idpay import put_initiative_reward_info
-from api.idpay import put_user_id_suspension
 from api.idpay import remove_payment_instrument
 from api.idpay import timeline
 from api.idpay import upload_merchant_csv
@@ -557,6 +558,15 @@ def tokenize_fc(fiscal_code: str):
 def suspend_citizen_from_initiative(initiative_id: str,
                                     fiscal_code: str):
     institution_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
-    res = put_user_id_suspension(initiative_id=initiative_id, fiscal_code=fiscal_code, selfcare_token=institution_token)
+    res = put_citizen_suspension(selfcare_token=institution_token, initiative_id=initiative_id, fiscal_code=fiscal_code)
+    assert res.status_code == 204
+    return res
+
+
+def readmit_citizen_to_initiative(initiative_id: str,
+                                  fiscal_code: str):
+    institution_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
+    res = put_citizen_readmission(selfcare_token=institution_token, initiative_id=initiative_id,
+                                  fiscal_code=fiscal_code)
     assert res.status_code == 204
     return res

--- a/util/utility.py
+++ b/util/utility.py
@@ -289,6 +289,29 @@ def clean_trx_files(source_filename: str):
         print(f'The file {source_filename} and its encrypted version does not exist')
 
 
+def retry_merchant_statistics(initiative_id: str,
+                              merchant_id: str,
+                              tries=10,
+                              delay=1):
+    count = 0
+
+    res = get_initiative_statistics_merchant_portal(
+        merchant_id=merchant_id,
+        initiative_id=initiative_id)
+
+    while res.status_code != 200:
+        count += 1
+        time.sleep(delay)
+        res = get_initiative_statistics_merchant_portal(
+            merchant_id=merchant_id,
+            initiative_id=initiative_id)
+        if count == tries:
+            break
+
+    assert res.status_code == 200
+    return res.json()
+
+
 def check_statistics(organization_id: str,
                      initiative_id: str,
                      old_statistics: dict,

--- a/util/utility.py
+++ b/util/utility.py
@@ -461,8 +461,12 @@ def natural_language_to_date_converter(natural_language_date: str):
         actual_date = datetime.datetime.now().strftime('%Y-%m-%d')
     elif natural_language_date == 'tomorrow':
         actual_date = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+    elif natural_language_date == 'day_after_tomorrow':
+        actual_date = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
     elif natural_language_date == 'future':
         actual_date = (datetime.datetime.now() + datetime.timedelta(days=365 * 5)).strftime('%Y-%m-%d')
+    elif natural_language_date == 'future_tomorrow':
+        actual_date = (datetime.datetime.now() + datetime.timedelta(days=365 * 5 + 1)).strftime('%Y-%m-%d')
     return actual_date
 
 

--- a/util/utility.py
+++ b/util/utility.py
@@ -556,7 +556,7 @@ def tokenize_fc(fiscal_code: str):
 
 def suspend_citizen_from_initiative(initiative_id: str,
                                     fiscal_code: str):
-    token = tokenize_fc(fiscal_code=fiscal_code)
-    res = put_user_id_suspension(initiative_id=initiative_id, user_id=token)
+    institution_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
+    res = put_user_id_suspension(initiative_id=initiative_id, fiscal_code=fiscal_code, selfcare_token=institution_token)
     assert res.status_code == 204
     return res

--- a/util/utility.py
+++ b/util/utility.py
@@ -476,6 +476,13 @@ def create_initiative(initiative_name_in_settings: str):
     institution_selfcare_token = get_selfcare_token(institution_info=secrets.selfcare_info.test_institution)
     initiative_id = post_initiative_info(selfcare_token=institution_selfcare_token).json()['initiativeId']
 
+    if 'rankingStartDate' in creation_payloads.general:
+        creation_payloads.general['rankingStartDate'] = natural_language_to_date_converter(
+            creation_payloads.general['rankingStartDate'])
+    if 'rankingEndDate' in creation_payloads.general:
+        creation_payloads.general['rankingEndDate'] = natural_language_to_date_converter(
+            creation_payloads.general['rankingEndDate'])
+
     creation_payloads.general['startDate'] = natural_language_to_date_converter(creation_payloads.general['startDate'])
     creation_payloads.general['endDate'] = natural_language_to_date_converter(creation_payloads.general['endDate'])
 


### PR DESCRIPTION
### Description
This PR proposes to add APIs and scenarios for citizen suspension and readmission.
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- add suspension and readmission APIs
- add suspension and readmission scenarios
- refactor environment.py to create more initiatives per feature
- fix existing scenarios (i.e. pre-authorization for non-onboard citizens)
<!--- Describe your changes in detail -->

### Motivation and context
With this change we functionally test user suspension and readmission.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [x] Yes
  - [x] `.secrets_template.yaml`
  - [x] Pipelines' secure file
  - [x] Confluence
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
