### PR TITLE
[IDP-1656] Add unsubscribe and type 4 tests

### DIFF
--- a/api/onboarding_io.py
+++ b/api/onboarding_io.py
@@ -6,7 +6,7 @@ from conf.configuration import settings
 
 
 def accept_terms_and_condition(token, initiative_id):
-    """API to accept terms and condition
+    """API to accept terms and conditions
         :param token: token IO
         :param initiative_id: initiative on which onboard the user
         :returns: the response of the call.

--- a/api/onboarding_io.py
+++ b/api/onboarding_io.py
@@ -5,7 +5,7 @@ import requests
 from conf.configuration import settings
 
 
-def accept_terms_and_condition(token, initiative_id):
+def accept_terms_and_conditions(token, initiative_id):
     """API to accept terms and conditions
         :param token: token IO
         :param initiative_id: initiative on which onboard the user

--- a/bdd/environment.py
+++ b/bdd/environment.py
@@ -9,7 +9,7 @@ from util.utility import create_initiative
 def before_all(context):
     """Initialize initiatives' IDs map
     """
-    secrets.initiatives = {}
+    secrets['newly_created'] = set()
 
 
 def before_feature(context, feature):
@@ -17,6 +17,8 @@ def before_feature(context, feature):
     """
     created = False
     # Create an initiative for each proper tag on feature file (if not created yet in this run)
+    if not secrets.initiatives:
+        secrets.initiatives = {}
     for curr_initiative_name in feature.tags:
         if curr_initiative_name in settings.initiatives:
             if curr_initiative_name not in secrets.initiatives.keys():
@@ -25,6 +27,7 @@ def before_feature(context, feature):
                     initiative_name_in_settings=curr_initiative_name)
                 print(
                     f'Created initiative {secrets.initiatives[curr_initiative_name]["id"]} ({curr_initiative_name})')
+                secrets['newly_created'].add(secrets.initiatives[curr_initiative_name]['id'])
                 created = True
 
     if created:
@@ -36,15 +39,15 @@ def after_all(context):
     """
 
     # Prevents the deletion of the fixed initiatives
-    fixed_initiatives = []
+    fixed_initiatives = set((x['id'] for x in secrets.initiatives.values())) - secrets.newly_created
 
     if not settings.KEEP_INITIATIVES_AFTER_TEST:
-        for initiative_id in secrets.initiatives.values():
-            if initiative_id not in fixed_initiatives:
-                res = delete_initiative(initiative_id=initiative_id['id'])
+        for initiative in secrets.initiatives.values():
+            if initiative['id'] not in fixed_initiatives:
+                res = delete_initiative(initiative_id=initiative['id'])
                 if res.status_code == 204:
                     print(
-                        f'Deleted initiative {initiative_id["id"]}')
+                        f'Deleted initiative {initiative["id"]}')
                 else:
                     print(
-                        f'Failed to delete initiative {initiative_id["id"]}')
+                        f'Failed to delete initiative {initiative["id"]}')

--- a/bdd/features/pilot/pilot_onboarding.feature
+++ b/bdd/features/pilot/pilot_onboarding.feature
@@ -33,30 +33,30 @@ Feature: A citizen A onboards the pilot initiative
 
   Scenario: User with self-declared incorrect criteria tries onboarding unsuccessfully
     Given the citizen A is 23 years old at most
-    And the citizen A accepts terms and condition
+    And the citizen A accepts terms and conditions
     When the citizen A insert self-declared criteria not correctly
     Then the onboard of A is KO
 
   Scenario: User under minimum age and with incorrect self-declared criteria tries onboarding unsuccessfully
     Given the citizen A is 17 years old at most
-    And the citizen A accepts terms and condition
+    And the citizen A accepts terms and conditions
     When the citizen A insert self-declared criteria not correctly
     Then the onboard of A is KO
 
   Scenario: User over the maximum age and with incorrect self-declared criteria tries onboarding unsuccessfully
     Given the citizen A is 36 years old at most
-    And the citizen A accepts terms and condition
+    And the citizen A accepts terms and conditions
     When the citizen A insert self-declared criteria not correctly
     Then the onboard of A is KO
 
   Scenario: User in age range with self-declared correct criteria tries onboarding unsuccessfully
     Given the citizen A is 25 years old tomorrow
-    And the citizen A accepts terms and condition
+    And the citizen A accepts terms and conditions
     When the citizen A insert self-declared criteria correctly
     Then the onboard of A is OK
 
   Scenario: User in age range with self-declared incorrect criteria tries onboarding unsuccessfully
     Given the citizen A is 25 years old at most
-    And the citizen A accepts terms and condition
+    And the citizen A accepts terms and conditions
     When the citizen A insert self-declared criteria not correctly
     Then the onboard of A is KO

--- a/bdd/features/pilot/pilot_suspension.feature
+++ b/bdd/features/pilot/pilot_suspension.feature
@@ -86,6 +86,6 @@ Feature: A citizen can be suspended from an initiative by the promoting institut
     And the citizen A is onboard
     And the citizen B is 25 years old at most
     And the institution suspends correctly the citizen A
-    When the citizen B tries to accept terms and condition
-    Then the latest accept terms and condition failed for budget terminated
+    When the citizen B tries to accept terms and conditions
+    Then the latest accept terms and conditions failed for budget terminated
     And the onboard of B is KO

--- a/bdd/features/pilot/pilot_transaction.feature
+++ b/bdd/features/pilot/pilot_transaction.feature
@@ -506,3 +506,10 @@ Feature: A transaction is generated, authorized and confirmed
     And the transaction X does not exists
     When the citizen A tries to pre-authorize the transaction X
     Then the latest pre-authorization fails because the transaction cannot be found
+
+  Scenario: Citizen authorizes a transaction before pre-authorization
+    Given the random merchant 1 is onboard
+    And the citizen A is onboard
+    And the merchant 1 generates the transaction X of amount 300000 cents
+    When the citizen A tries to authorize the transaction X
+    Then the latest authorization fails because the user did not pre-authorize the transaction

--- a/bdd/features/pilot/pilot_unsubscription.feature
+++ b/bdd/features/pilot/pilot_unsubscription.feature
@@ -8,6 +8,17 @@ Feature: A transaction is generated, authorized and confirmed
     And the citizen A is 25 years old at most
     And the citizen A is onboard
 
+  Scenario: A citizen onboard tries to unsubscribe and receives OK
+    When the citizen A tries to unsubscribe
+    Then the latest unsubscribe is OK
+    And the onboard of A is unsubscribed
+
+  @need_fix
+  Scenario: An unsubscribed citizen tries to unsubscribe again and receives a KO
+    Given the citizen A is unsubscribed
+    When the citizen A tries to unsubscribe
+    Then the latest unsubscribe is KO
+
   Scenario: An unsubscribed citizen tries to onboard and fails
     Given the citizen A is unsubscribed
     When the citizen A tries to accept terms and conditions
@@ -21,7 +32,15 @@ Feature: A transaction is generated, authorized and confirmed
     When the citizen A tries to pre-authorize the transaction X
     Then the transaction X is not authorized
 
-  Scenario: An unsubscribed citizen tries to authorize a transaction X
+  Scenario: An unsubscribed citizen tries to onboard another initiative
     Given the citizen A is unsubscribed
     When the citizen A tries to onboard the initiative Scontoditipo1_not_started
     Then the onboard of A is OK
+
+  Scenario: The transaction made before unsubscribing is present in the rewards file
+    Given the random merchant 1 is onboard
+    And the merchant 1 generates the transaction X of amount 20001 cents
+    And the citizen A confirms the transaction X
+    And the citizen A is unsubscribed
+    When the batch process confirms the transaction X
+    Then the merchant 1 is refunded 200.01 euros

--- a/bdd/features/pilot/pilot_unsubscription.feature
+++ b/bdd/features/pilot/pilot_unsubscription.feature
@@ -13,11 +13,11 @@ Feature: A transaction is generated, authorized and confirmed
     Then the latest unsubscribe is OK
     And the onboard of A is unsubscribed
 
-  @need_fix
-  Scenario: An unsubscribed citizen tries to unsubscribe again and receives a KO
+  @need_fix @IDP-1710
+  Scenario: An unsubscribed citizen tries to unsubscribe again and receives OK
     Given the citizen A is unsubscribed
     When the citizen A tries to unsubscribe
-    Then the latest unsubscribe is KO
+    Then the latest unsubscribe is OK
 
   Scenario: An unsubscribed citizen tries to onboard and fails
     Given the citizen A is unsubscribed

--- a/bdd/features/pilot/pilot_unsubscription.feature
+++ b/bdd/features/pilot/pilot_unsubscription.feature
@@ -21,7 +21,6 @@ Feature: A transaction is generated, authorized and confirmed
     When the citizen A tries to pre-authorize the transaction X
     Then the transaction X is not authorized
 
-    @test
   Scenario: An unsubscribed citizen tries to authorize a transaction X
     Given the citizen A is unsubscribed
     When the citizen A tries to onboard the initiative Scontoditipo1_not_started

--- a/bdd/features/pilot/pilot_unsubscription.feature
+++ b/bdd/features/pilot/pilot_unsubscription.feature
@@ -1,0 +1,28 @@
+@Scontoditipo1
+@Scontoditipo1_not_started
+@unsubscribe
+Feature: A transaction is generated, authorized and confirmed
+
+  Background:
+    Given the initiative is "Scontoditipo1"
+    And the citizen A is 25 years old at most
+    And the citizen A is onboard
+
+  Scenario: An unsubscribed citizen tries to onboard and fails
+    Given the citizen A is unsubscribed
+    When the citizen A tries to accept terms and conditions
+    Then the latest accept terms and conditions failed for user unsubscribed
+    And the onboard of A is unsubscribed
+
+  Scenario: An unsubscribed citizen tries to authorize a transaction X
+    Given the citizen A is unsubscribed
+    And the random merchant 1 is onboard
+    And the merchant 1 generates the transaction X of amount 15000 cents
+    When the citizen A tries to pre-authorize the transaction X
+    Then the transaction X is not authorized
+
+    @test
+  Scenario: An unsubscribed citizen tries to authorize a transaction X
+    Given the citizen A is unsubscribed
+    When the citizen A tries to onboard the initiative Scontoditipo1_not_started
+    Then the onboard of A is OK

--- a/bdd/features/pilot/pilot_unsubscription.feature
+++ b/bdd/features/pilot/pilot_unsubscription.feature
@@ -44,3 +44,10 @@ Feature: A transaction is generated, authorized and confirmed
     And the citizen A is unsubscribed
     When the batch process confirms the transaction X
     Then the merchant 1 is refunded 200.01 euros
+
+  Scenario: A suspended citizen can unsubscribe
+    Given the institution suspends the citizen A
+    And the citizen A is suspended
+    When the citizen A tries to unsubscribe
+    Then the latest unsubscribe is OK
+    And the onboard of A is unsubscribed

--- a/bdd/features/tipo4/_onboarding.feature
+++ b/bdd/features/tipo4/_onboarding.feature
@@ -7,5 +7,6 @@ Feature: A citizen A onboards the pilot initiative
 
   Scenario: The citizen tries to onboard on a closed initiative
     Given the citizen A has fiscal code random
-    When the citizen A tries to onboard
-    Then the onboard of A is KO
+    When the citizen A tries to accept terms and conditions
+    Then the latest accept terms and conditions failed for initiative ended
+    And the onboard of A is KO

--- a/bdd/features/tipo4/_onboarding.feature
+++ b/bdd/features/tipo4/_onboarding.feature
@@ -1,0 +1,11 @@
+@Scontoditipo4
+@onboarding
+Feature: A citizen A onboards the pilot initiative
+
+  Background:
+    Given the initiative is "Scontoditipo4"
+
+  Scenario: The citizen tries to onboard on a closed initiative
+    Given the citizen A has fiscal code random
+    When the citizen A tries to onboard
+    Then the onboard of A is KO

--- a/bdd/features/tipo4/_onboarding.feature
+++ b/bdd/features/tipo4/_onboarding.feature
@@ -1,6 +1,6 @@
 @Scontoditipo4
 @onboarding
-Feature: A citizen A onboards the pilot initiative
+Feature: Onboarding on a closed initiative
 
   Background:
     Given the initiative is "Scontoditipo4"
@@ -8,5 +8,5 @@ Feature: A citizen A onboards the pilot initiative
   Scenario: The citizen tries to onboard on a closed initiative
     Given the citizen A has fiscal code random
     When the citizen A tries to accept terms and conditions
-    Then the latest accept terms and conditions failed for initiative ended
+    Then the latest accept terms and conditions failed for onboarding period ended
     And the onboard of A is KO

--- a/bdd/features/tipo4/_transaction.feature
+++ b/bdd/features/tipo4/_transaction.feature
@@ -1,0 +1,11 @@
+@Scontoditipo4
+@onboarding
+Feature: A citizen A onboards the pilot initiative
+
+  Background:
+    Given the initiative is "Scontoditipo4"
+
+  Scenario: Transaction X is not generated on a closed initiative
+    Given the random merchant 1 is onboard
+    When the merchant 1 tries to generate a transaction X of amount 1000 cents
+    Then the transaction X is not generated

--- a/bdd/features/tipo4/_transaction.feature
+++ b/bdd/features/tipo4/_transaction.feature
@@ -1,6 +1,6 @@
 @Scontoditipo4
 @onboarding
-Feature: A citizen A onboards the pilot initiative
+Feature: Transaction in a closed initiative
 
   Background:
     Given the initiative is "Scontoditipo4"

--- a/bdd/features/tipo4/_transaction.feature
+++ b/bdd/features/tipo4/_transaction.feature
@@ -7,5 +7,5 @@ Feature: A citizen A onboards the pilot initiative
 
   Scenario: Transaction X is not generated on a closed initiative
     Given the random merchant 1 is onboard
-    When the merchant 1 tries to generate a transaction X of amount 1000 cents
-    Then the transaction X is not generated
+    When the merchant 1 tries to generate the transaction X of amount 1000 cents
+    Then the transaction X is not created because the initiative is terminated

--- a/bdd/steps/dataset_steps.py
+++ b/bdd/steps/dataset_steps.py
@@ -11,15 +11,14 @@ from util.dataset_utility import fake_fc
 from util.utility import get_io_token
 
 
-@given('the citizen has fiscal code {citizen_fc}')
-def step_citizen_fc_exact_or_random(context, citizen_fc):
+@given('the citizen {citizen_name} has fiscal code {citizen_fc}')
+def step_citizen_fc_exact_or_random(context, citizen_name, citizen_fc):
     if citizen_fc == 'random':
         citizen_fc = fake_fc()
 
     context.latest_citizen_fc = citizen_fc
     context.latest_token_io = get_io_token(citizen_fc)
-
-    return citizen_fc
+    context.citizens_fc[citizen_name] = citizen_fc
 
 
 @given('the citizen {citizen_name} is {age} years old {precision}')

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -37,7 +37,7 @@ def step_when_merchant_tries_to_create_a_transaction(context, merchant_name, trx
         merchant_id=curr_merchant_id
     )
 
-    context.transactions[trx_name] = context.latest_create_transaction_response
+    context.transactions[trx_name] = context.latest_create_transaction_response.json()
 
 
 @when(

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -429,6 +429,14 @@ def step_check_latest_pre_authorization_failed_user_suspended(context):
                'message'] == f'User {curr_tokenized_fc} has been suspended for initiative {context.initiative_id}'
 
 
+@then('the latest authorization fails because the user did not pre-authorize the transaction')
+def step_check_latest_pre_authorization_failed_missing_pre_auth(context):
+    assert context.latest_authorization_response.status_code == 400
+    assert context.latest_authorization_response.json()['code'] == 'PAYMENT_STATUS_NOT_VALID'
+    assert context.latest_authorization_response.json()[
+               'message'] == f'Cannot relate transaction in status CREATED'
+
+
 @then('the latest authorization fails because the transaction cannot be found')
 def step_check_latest_authorization_failed(context):
     assert context.latest_authorization_response.status_code == 404

--- a/bdd/steps/discount_transaction_steps.py
+++ b/bdd/steps/discount_transaction_steps.py
@@ -146,6 +146,13 @@ def step_check_named_transaction_status(context, trx_name, expected_status):
             'message'].startswith('Cannot create transaction with invalid amount: ')
         return
 
+    if status == 'NOT CREATED BECAUSE THE INITIATIVE IS TERMINATED':
+        assert context.latest_create_transaction_response.status_code == 400
+        assert context.latest_create_transaction_response.json()['code'] == 'INVALID DATE'
+        assert context.latest_create_transaction_response.json()[
+                   'message'] == f'Cannot create transaction out of valid period. Initiative startDate: {context.initiative_settings["fruition_start"][:10]} endDate: {context.initiative_settings["fruition_end"][:10]}'
+        return
+
     if status == 'ALREADY AUTHORIZED':
         assert context.latest_pre_authorization_response.status_code == 403
         assert context.latest_pre_authorization_response.json()['code'] == 'PAYMENT_ALREADY_AUTHORIZED'

--- a/bdd/steps/initiative_steps.py
+++ b/bdd/steps/initiative_steps.py
@@ -72,7 +72,7 @@ def step_allocate_initiative_budget(context, precision):
                                                         initiative_id=context.initiative_id).json()
 
     while context.base_statistics['onboardedCitizenCount'] < allowable_citizens:
-        context.citizens_fc[str(i)] = step_citizen_fc_exact_or_random(context=context, citizen_fc='random')
+        step_citizen_fc_exact_or_random(context=context, citizen_name=str(i), citizen_fc='random')
         step_named_citizen_onboard(context=context, citizen_name=str(i))
         context.base_statistics = get_initiative_statistics(organization_id=secrets.organization_id,
                                                             initiative_id=context.initiative_id).json()

--- a/bdd/steps/initiative_steps.py
+++ b/bdd/steps/initiative_steps.py
@@ -16,7 +16,7 @@ from util.utility import check_statistics
 @given('the initiative is "{initiative_name}"')
 def step_given_initiative_id(context, initiative_name):
     context.initiative_id = secrets.initiatives[initiative_name]['id']
-    context.initiatives_settings = settings.initiatives[initiative_name]
+    context.initiative_settings = settings.initiatives[initiative_name]
     base_context_initialization(context)
 
 
@@ -30,10 +30,10 @@ def step_check_initiative_statistics_updated(context):
 
 
 def base_context_initialization(context):
-    context.cashback_percentage = context.initiatives_settings.get('cashback_percentage')
-    context.budget_per_citizen = context.initiatives_settings['budget_per_citizen']
-    context.fruition_start = context.initiatives_settings['fruition_start']
-    context.total_budget = context.initiatives_settings.get('total_budget')
+    context.cashback_percentage = context.initiative_settings.get('cashback_percentage')
+    context.budget_per_citizen = context.initiative_settings['budget_per_citizen']
+    context.fruition_start = context.initiative_settings['fruition_start']
+    context.total_budget = context.initiative_settings.get('total_budget')
 
     context.trx_date = (datetime.datetime.now(pytz.timezone('Europe/Rome')) + datetime.timedelta(days=1)).strftime(
         settings.iso_date_format)

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -93,7 +93,7 @@ def step_check_latest_accept_tc_failed(context, reason_ko):
         assert context.accept_tc_response.status_code == 400
         assert context.accept_tc_response.json()['message'] == 'Unsubscribed to initiative'
         assert context.accept_tc_response.json()['details'] == 'GENERIC_ERROR'
-    elif reason == 'INITIATIVE ENDED':
+    elif reason == 'ONBOARDING PERIOD ENDED':
         assert context.accept_tc_response.status_code == 403
         assert context.accept_tc_response.json()[
                    'message'] == 'The opportunity to join the initiative has already ended'

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -66,6 +66,16 @@ def step_citizen_tries_to_onboard(context, citizen_name):
     step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='correctly')
 
 
+@when('the citizen {citizen_name} tries to onboard the initiative {initiative_name}')
+def step_citizen_tries_to_onboard_named_initiative(context, citizen_name, initiative_name):
+    new_context = context
+    new_context.initiative_id = secrets.initiatives[initiative_name]['id']
+    context.base_statistics = get_initiative_statistics(organization_id=secrets.organization_id,
+                                                        initiative_id=context.initiative_id).json()
+    step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
+    step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='correctly')
+
+
 @when('the citizen {citizen_name} tries to accept terms and conditions')
 def step_citizen_tries_to_accept_terms_and_condition(context, citizen_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -66,13 +66,13 @@ def step_citizen_tries_to_onboard(context, citizen_name):
     step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='correctly')
 
 
-@when('the citizen {citizen_name} tries to accept terms and condition')
+@when('the citizen {citizen_name} tries to accept terms and conditions')
 def step_citizen_tries_to_accept_terms_and_condition(context, citizen_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])
     context.accept_tc_response = accept_terms_and_condition(token=token_io, initiative_id=context.initiative_id)
 
 
-@then('the latest accept terms and condition failed for {reason_ko}')
+@then('the latest accept terms and conditions failed for {reason_ko}')
 def step_check_latest_accept_tc_failed(context, reason_ko):
     reason = reason_ko.upper()
     assert context.accept_tc_response.status_code == 403
@@ -80,7 +80,7 @@ def step_check_latest_accept_tc_failed(context, reason_ko):
         assert context.accept_tc_response.json()['details'] == 'BUDGET_TERMINATED'
 
 
-@given('the citizen {citizen_name} accepts terms and condition')
+@given('the citizen {citizen_name} accepts terms and conditions')
 def step_citizen_accept_terms_and_condition(context, citizen_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])
     context.accept_tc_response = accept_terms_and_condition(token=token_io, initiative_id=context.initiative_id)

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -162,7 +162,7 @@ def step_check_onboarding_status(context, citizen_name, status):
         retry_timeline(expected=timeline_operations.onboarding, request=timeline, num_required=1, token=token_io,
                        initiative_id=context.initiative_id, field='operationType', tries=10, delay=3,
                        message='Not onboard')
-        expect_wallet_counters(expected_amount=context.initiatives_settings['budget_per_citizen'],
+        expect_wallet_counters(expected_amount=context.initiative_settings['budget_per_citizen'],
                                expected_accrued=0,
                                token=token_io,
                                initiative_id=context.initiative_id)

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -38,6 +38,7 @@ def step_named_citizen_onboard(context, citizen_name):
     step_check_onboarding_status(context=context, citizen_name=citizen_name, status='OK')
 
 
+@given('the citizen {citizen_name} is suspended')
 @then('the citizen {citizen_name} is suspended')
 def step_named_citizen_suspension(context, citizen_name):
     step_check_onboarding_status(context=context, citizen_name=citizen_name, status='SUSPENDED')

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -93,6 +93,11 @@ def step_check_latest_accept_tc_failed(context, reason_ko):
         assert context.accept_tc_response.status_code == 400
         assert context.accept_tc_response.json()['message'] == 'Unsubscribed to initiative'
         assert context.accept_tc_response.json()['details'] == 'GENERIC_ERROR'
+    elif reason == 'INITIATIVE ENDED':
+        assert context.accept_tc_response.status_code == 403
+        assert context.accept_tc_response.json()[
+                   'message'] == 'The opportunity to join the initiative has already ended'
+        assert context.accept_tc_response.json()['details'] == 'INITIATIVE_END'
     else:
         assert False, 'Uncovered fail reason'
 

--- a/bdd/steps/onboarding_steps.py
+++ b/bdd/steps/onboarding_steps.py
@@ -7,7 +7,7 @@ from api.idpay import get_initiative_statistics
 from api.idpay import get_initiative_statistics_merchant_portal
 from api.idpay import timeline
 from api.idpay import wallet
-from api.onboarding_io import accept_terms_and_condition
+from api.onboarding_io import accept_terms_and_conditions
 from api.onboarding_io import status_onboarding
 from conf.configuration import secrets
 from conf.configuration import settings
@@ -33,7 +33,7 @@ timeline_operations = settings.IDPAY.endpoints.timeline.operations
 @given('the citizen {citizen_name} is onboard')
 @given('the citizen {citizen_name} is onboarded')
 def step_named_citizen_onboard(context, citizen_name):
-    step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
+    step_citizen_accept_terms_and_conditions(context=context, citizen_name=citizen_name)
     step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='correctly')
     step_check_onboarding_status(context=context, citizen_name=citizen_name, status='OK')
 
@@ -51,7 +51,7 @@ def step_named_citizen_suspension(context, citizen_name):
 
 @given('the citizen {citizen_name} is not onboard')
 def step_citizen_not_onboard(context, citizen_name):
-    step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
+    step_citizen_accept_terms_and_conditions(context=context, citizen_name=citizen_name)
     step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='not correctly')
     check_statistics(organization_id=context.organization_id,
                      initiative_id=context.initiative_id,
@@ -63,7 +63,7 @@ def step_citizen_not_onboard(context, citizen_name):
 
 @when('the citizen {citizen_name} tries to onboard')
 def step_citizen_tries_to_onboard(context, citizen_name):
-    step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
+    step_citizen_accept_terms_and_conditions(context=context, citizen_name=citizen_name)
     step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='correctly')
 
 
@@ -73,14 +73,14 @@ def step_citizen_tries_to_onboard_named_initiative(context, citizen_name, initia
     new_context.initiative_id = secrets.initiatives[initiative_name]['id']
     context.base_statistics = get_initiative_statistics(organization_id=secrets.organization_id,
                                                         initiative_id=context.initiative_id).json()
-    step_citizen_accept_terms_and_condition(context=context, citizen_name=citizen_name)
+    step_citizen_accept_terms_and_conditions(context=context, citizen_name=citizen_name)
     step_insert_self_declared_criteria(context=context, citizen_name=citizen_name, correctness='correctly')
 
 
 @when('the citizen {citizen_name} tries to accept terms and conditions')
-def step_citizen_tries_to_accept_terms_and_condition(context, citizen_name):
+def step_citizen_tries_to_accept_terms_and_conditions(context, citizen_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])
-    context.accept_tc_response = accept_terms_and_condition(token=token_io, initiative_id=context.initiative_id)
+    context.accept_tc_response = accept_terms_and_conditions(token=token_io, initiative_id=context.initiative_id)
 
 
 @then('the latest accept terms and conditions failed for {reason_ko}')
@@ -103,9 +103,9 @@ def step_check_latest_accept_tc_failed(context, reason_ko):
 
 
 @given('the citizen {citizen_name} accepts terms and conditions')
-def step_citizen_accept_terms_and_condition(context, citizen_name):
+def step_citizen_accept_terms_and_conditions(context, citizen_name):
     token_io = get_io_token(context.citizens_fc[citizen_name])
-    context.accept_tc_response = accept_terms_and_condition(token=token_io, initiative_id=context.initiative_id)
+    context.accept_tc_response = accept_terms_and_conditions(token=token_io, initiative_id=context.initiative_id)
     assert context.accept_tc_response.status_code == 204
 
 

--- a/bdd/steps/rewards_step.py
+++ b/bdd/steps/rewards_step.py
@@ -33,7 +33,7 @@ def step_check_rewards_on_wallet(context, token_io):
 def step_check_rewards_of_citizen(context, citizen_name, expected_accrued):
     expected_accrued = float(expected_accrued)
     curr_token_io = get_io_token(context.citizens_fc[citizen_name])
-    expected_amount_left = round(context.initiatives_settings['budget_per_citizen'] - expected_accrued, 2)
+    expected_amount_left = round(context.initiative_settings['budget_per_citizen'] - expected_accrued, 2)
 
     expect_wallet_counters(expected_amount=expected_amount_left, expected_accrued=expected_accrued, token=curr_token_io,
                            initiative_id=context.initiative_id)
@@ -43,7 +43,7 @@ def step_check_rewards_of_citizen(context, citizen_name, expected_accrued):
 def step_check_transaction_cancellation_on_citizen(context, citizen_name):
     curr_token_io = get_io_token(context.citizens_fc[citizen_name])
 
-    expect_wallet_counters(expected_amount=context.initiatives_settings['budget_per_citizen'], expected_accrued=0,
+    expect_wallet_counters(expected_amount=context.initiative_settings['budget_per_citizen'], expected_accrued=0,
                            token=curr_token_io,
                            initiative_id=context.initiative_id)
 
@@ -60,8 +60,8 @@ def step_check_transaction_cancellation_on_citizen(context, citizen_name):
 
 @given('an expected accrued')
 def step_set_expected_accrued(context):
-    context.cashback_percentage = context.initiatives_settings['cashback_percentage']
-    context.budget_per_citizen = context.initiatives_settings['budget_per_citizen']
+    context.cashback_percentage = context.initiative_settings['cashback_percentage']
+    context.budget_per_citizen = context.initiative_settings['budget_per_citizen']
     if round(floor(context.amount_cents * context.cashback_percentage) / 10000, 2) > context.budget_per_citizen:
         expected_accrued = context.budget_per_citizen
         expected_accrued_cents = floor(context.budget_per_citizen * 100)

--- a/bdd/steps/suspension_readmission_steps.py
+++ b/bdd/steps/suspension_readmission_steps.py
@@ -11,6 +11,7 @@ from util.utility import readmit_citizen_to_initiative
 from util.utility import suspend_citizen_from_initiative
 
 
+@given('the institution suspends the citizen {citizen_name}')
 @when('the institution suspends the citizen {citizen_name}')
 def step_institution_suspends_citizen(context, citizen_name):
     suspend_citizen_from_initiative(initiative_id=context.initiative_id, fiscal_code=context.citizens_fc[citizen_name])

--- a/bdd/steps/unsubscribe_steps.py
+++ b/bdd/steps/unsubscribe_steps.py
@@ -1,0 +1,9 @@
+from behave import given
+
+from util.utility import citizen_unsubscribe_from_initiative
+
+
+@given('the citizen {citizen_name} is unsubscribed')
+def step_institution_suspends_citizen(context, citizen_name):
+    citizen_unsubscribe_from_initiative(initiative_id=context.initiative_id,
+                                        fiscal_code=context.citizens_fc[citizen_name])

--- a/bdd/steps/unsubscribe_steps.py
+++ b/bdd/steps/unsubscribe_steps.py
@@ -1,9 +1,31 @@
 from behave import given
+from behave import then
+from behave import when
 
+from api.idpay import unsubscribe
 from util.utility import citizen_unsubscribe_from_initiative
+from util.utility import get_io_token
+
+
+@when('the citizen {citizen_name} tries to unsubscribe')
+def step_citizen_tries_to_unsubscribe(context, citizen_name):
+    token = get_io_token(context.citizens_fc[citizen_name])
+    res = unsubscribe(context.initiative_id, token)
+    context.latest_unsubscribe_response = res
+
+
+@then('the latest unsubscribe is {status}')
+def step_check_latest_cancellation_failed(context, status):
+    status = status.upper()
+    if status == 'OK':
+        assert context.latest_unsubscribe_response.status_code == 204
+    elif status == 'KO':
+        assert context.latest_unsubscribe_response.status_code == 400
+    else:
+        assert False, f'Uncovered case {status}'
 
 
 @given('the citizen {citizen_name} is unsubscribed')
-def step_institution_suspends_citizen(context, citizen_name):
+def step_citizen_unsubscribes(context, citizen_name):
     citizen_unsubscribe_from_initiative(initiative_id=context.initiative_id,
                                         fiscal_code=context.citizens_fc[citizen_name])

--- a/conf/.secrets_template.yaml
+++ b/conf/.secrets_template.yaml
@@ -17,6 +17,8 @@ uat:
       id: <COMPLEX_ID>
     timeframes:
       id: <TIMEFRAMES_ID>
+    Scontoditipo4:
+      id: <SCONTO_DI_TIPO_4_ID>
   pm:
     pub_key: <PM_PUBLIC_KEY>
   selfcare_info:

--- a/settings.yaml
+++ b/settings.yaml
@@ -384,3 +384,9 @@ initiatives:
       refund:
         timeParameter:
           timeType: 'DAILY'
+  Scontoditipo4:
+    id: 'SCONTOTIPO4'
+    cashback_percentage: 100
+    budget_per_citizen: 1
+    fruition_start: '2023-09-04T00:00:00.000+02:00'
+    fruition_end: '2023-09-05:59:59.000+02:00'

--- a/tests/test_cashback_like/test_cashback_like.py
+++ b/tests/test_cashback_like/test_cashback_like.py
@@ -12,14 +12,14 @@ from api.idpay import timeline
 from api.idpay import unsubscribe
 from api.idpay import wallet
 from api.issuer import enroll
-from api.onboarding_io import accept_terms_and_condition
+from api.onboarding_io import accept_terms_and_conditions
 from conf.configuration import secrets
 from conf.configuration import settings
 from util.certs_loader import load_pm_public_key
+from util.dataset_utility import Reward
 from util.dataset_utility import fake_fc
 from util.dataset_utility import fake_iban
 from util.dataset_utility import fake_pan
-from util.dataset_utility import Reward
 from util.encrypt_utilities import pgp_string_routine
 from util.transaction_upload import encrypt_and_upload
 from util.utility import card_enroll
@@ -1061,7 +1061,7 @@ def test_onboarding_after_unsubscribe():
     assert [] == get_payment_instruments(initiative_id=initiative_id, token=token).json()['instrumentList']
 
     # 1.24.1
-    res = accept_terms_and_condition(token, initiative_id)
+    res = accept_terms_and_conditions(token, initiative_id)
     assert res.status_code == 400
     assert res.json()['code'] == 400
     assert settings.IDPAY.endpoints.onboarding.unsubscribed_message == res.json()['message']
@@ -1221,7 +1221,7 @@ def test_onboarding_after_unsubscribe():
     assert [] == get_payment_instruments(initiative_id=initiative_id, token=token_a).json()['instrumentList']
 
     # 1.28.9
-    res = accept_terms_and_condition(token_a, initiative_id)
+    res = accept_terms_and_conditions(token_a, initiative_id)
     assert res.status_code == 400
     assert res.json()['code'] == 400
     assert settings.IDPAY.endpoints.onboarding.unsubscribed_message == res.json()['message']
@@ -1308,7 +1308,7 @@ def test_homocode_onboarding():
     clean_trx_files(curr_file_name)
 
     token1 = get_io_token(test_fc)
-    res = accept_terms_and_condition(token1, initiative_id)
+    res = accept_terms_and_conditions(token1, initiative_id)
     # 1.27.7
     assert res.status_code != 204
 

--- a/tests/test_cashback_like/test_onboarding_io.py
+++ b/tests/test_cashback_like/test_onboarding_io.py
@@ -10,7 +10,7 @@ import pytest
 from api.idpay import get_initiative_statistics
 from api.idpay import timeline
 from api.idpay import wallet
-from api.onboarding_io import accept_terms_and_condition
+from api.onboarding_io import accept_terms_and_conditions
 from api.onboarding_io import pdnd_autocertification
 from api.token_io import introspect
 from api.token_io import login
@@ -79,7 +79,7 @@ def test_onboard_unicode():
     res = introspect(token)
     assert res.json()['fiscal_code'] == test_fc
 
-    res = accept_terms_and_condition(token, initiative_id)
+    res = accept_terms_and_conditions(token, initiative_id)
     assert res.status_code == 400
     assert res.json()['code'] == 'FISCAL_CODE_NOT_VALID'
     assert res.json()['message'] == settings.IDPAY.endpoints.onboarding.enrollment.invalid_fc_message
@@ -102,7 +102,7 @@ def test_onboard_long_fc():
     res = introspect(token)
     assert res.json()['fiscal_code'] == test_fc
 
-    res = accept_terms_and_condition(token, initiative_id)
+    res = accept_terms_and_conditions(token, initiative_id)
     assert res.status_code == 400
     assert res.json()['code'] == 'FISCAL_CODE_NOT_VALID'
     assert res.json()['message'] == settings.IDPAY.endpoints.onboarding.enrollment.invalid_fc_message
@@ -155,7 +155,7 @@ def test_onboard_two_times():
     old_statistics = get_initiative_statistics(organization_id=organization_id, initiative_id=initiative_id).json()
 
     token = get_io_token(test_fc)
-    res = accept_terms_and_condition(token, initiative_id)
+    res = accept_terms_and_conditions(token, initiative_id)
     assert res.status_code == 204
     check_statistics(organization_id=organization_id, initiative_id=initiative_id, old_statistics=old_statistics,
                      onboarded_citizen_count_increment=0, accrued_rewards_increment=0,

--- a/tests/test_not_started/test_fail_onboard_io.py
+++ b/tests/test_not_started/test_fail_onboard_io.py
@@ -2,7 +2,7 @@
 """
 import pytest
 
-from api.onboarding_io import accept_terms_and_condition
+from api.onboarding_io import accept_terms_and_conditions
 from api.token_io import login
 from conf.configuration import secrets
 from conf.configuration import settings
@@ -18,7 +18,7 @@ def test_fail_onboarding():
 
     res = login(test_fc)
     token = res.content.decode('utf-8')
-    res = accept_terms_and_condition(token, secrets.initiatives.not_started.id)
+    res = accept_terms_and_conditions(token, secrets.initiatives.not_started.id)
 
     assert res.json()['code'] == 403
     assert res.json()['message'] == settings.initiatives.not_started.message
@@ -33,5 +33,5 @@ def test_fail_onboarding_wrong_token():
     test_fc = dataset_utility.fake_fc()
     res = login(test_fc)
     token = res.content.decode('utf-8')
-    res = accept_terms_and_condition(token + '0', secrets.initiatives.not_started.id)
+    res = accept_terms_and_conditions(token + '0', secrets.initiatives.not_started.id)
     assert res.status_code == 401

--- a/util/utility.py
+++ b/util/utility.py
@@ -31,7 +31,7 @@ from api.idpay import unsubscribe
 from api.idpay import upload_merchant_csv
 from api.idpay import wallet
 from api.issuer import enroll
-from api.onboarding_io import accept_terms_and_condition
+from api.onboarding_io import accept_terms_and_conditions
 from api.onboarding_io import check_prerequisites
 from api.onboarding_io import pdnd_autocertification
 from api.onboarding_io import status_onboarding
@@ -42,10 +42,10 @@ from conf.configuration import secrets
 from conf.configuration import settings
 from util import dataset_utility
 from util.certs_loader import load_pm_public_key
+from util.dataset_utility import Reward
 from util.dataset_utility import fake_iban
 from util.dataset_utility import fake_vat
 from util.dataset_utility import hash_pan
-from util.dataset_utility import Reward
 from util.encrypt_utilities import pgp_string_routine
 
 timeline_operations = settings.IDPAY.endpoints.timeline.operations
@@ -73,7 +73,7 @@ def onboard_io(fc, initiative_id):
     """
     token = get_io_token(fc)
 
-    res = accept_terms_and_condition(token, initiative_id)
+    res = accept_terms_and_conditions(token, initiative_id)
     assert res.status_code == 204
 
     retry_io_onboarding(expected='ACCEPTED_TC', request=status_onboarding, token=token,

--- a/util/utility.py
+++ b/util/utility.py
@@ -27,6 +27,7 @@ from api.idpay import put_initiative_refund_info
 from api.idpay import put_initiative_reward_info
 from api.idpay import remove_payment_instrument
 from api.idpay import timeline
+from api.idpay import unsubscribe
 from api.idpay import upload_merchant_csv
 from api.idpay import wallet
 from api.issuer import enroll
@@ -48,6 +49,7 @@ from util.dataset_utility import Reward
 from util.encrypt_utilities import pgp_string_routine
 
 timeline_operations = settings.IDPAY.endpoints.timeline.operations
+wallet_statuses = settings.IDPAY.endpoints.wallet.statuses
 
 
 def get_io_token(fc):
@@ -593,3 +595,14 @@ def readmit_citizen_to_initiative(initiative_id: str,
                                   fiscal_code=fiscal_code)
     assert res.status_code == 204
     return res
+
+
+def citizen_unsubscribe_from_initiative(initiative_id: str,
+                                        fiscal_code: str):
+    token = get_io_token(fiscal_code)
+    res = unsubscribe(initiative_id, token)
+    assert res.status_code == 204
+    retry_wallet(expected=wallet_statuses.unsubscribed, request=wallet, token=token,
+                 initiative_id=initiative_id, field='status', tries=3, delay=3)
+    retry_wallet(expected=wallet_statuses.unsubscribed, request=wallet, token=token,
+                 initiative_id=initiative_id, field='status', tries=3, delay=3)


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add unsubscription scenarios and type 4 ("initiative closed") initiative tests.
### List of changes
- add unsubscribe steps
- add type 4 scenarios
- fix fixed initiatives deletion
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can test what happens when a citizen unsubscribes from an initiative.
We also test scenario of a closed initiative.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [x] Yes
  - [x] `.secrets_template.yaml`
  - [x] Pipelines' secure file
  - [x] Confluence
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
