### PR TITLE
fix: [IDP-1342] removed casting string to float in field in statistics

### DIFF
--- a/util/utility.py
+++ b/util/utility.py
@@ -385,8 +385,8 @@ def check_statistics(organization_id: str,
         are_onboards_incremented = (current_statistics['onboardedCitizenCount'] == old_statistics[
             'onboardedCitizenCount'] + onboarded_citizen_count_increment)
 
-        are_accrued_rewards_incremented = (float(current_statistics['accruedRewards'].replace(',', '.')) == round(float(
-            old_statistics['accruedRewards'].replace(',', '.')) + accrued_rewards_increment, 2))
+        are_accrued_rewards_incremented = (float(current_statistics['accruedRewards']) == round(float(
+            old_statistics['accruedRewards']) + accrued_rewards_increment, 2))
 
         if not skip_trx_check:
             are_trxs_incremented = (


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- removed casting string to float about "accruedRewards" in check statistics

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is due to a fix about statistics response ->  [IDP-1342](https://pagopa.atlassian.net/browse/IDP-1342)

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `pipenv run pip freeze > requirements.txt`
- `pipenv install -r requirements.txt`

and check for changes.

- [ ] Yes
  - [ ] `requirements.txt`
  - [ ] `Pipfile`
  - [ ] `Pipfile.lock`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


[IDP-1342]: https://pagopa.atlassian.net/browse/IDP-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ