### PR TITLE
fix: [IDP-2173] Split test run

### DIFF
--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -49,6 +49,13 @@ stages:
       name: $(selfHostedAgentPool)
     jobs:
       - job: "Run_functional_tests"
+        strategy:
+          maxParallel: 2
+          matrix:
+            onboarding:
+              tag: 'onboarding'
+            transaction:
+              tag: 'transaction'
         steps:
           - checkout: self
           - script: |
@@ -66,13 +73,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              if [ -z "${{ parameters.tag }}" ] || [ "${{ parameters.tag }}" = "all_skip" ]; then
-                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "~skip"
-              elif [ "${{ parameters.tag }}" = "all" ]; then
-                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave"
-              else
-                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ parameters.tag }}"
-              fi
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -52,8 +52,6 @@ stages:
             transaction:
               current_tag: 'transaction'
         steps:
-          - script: echo "##vso[task.setvariable variable=behave_tag]$(current_tag)"
-            displayName: Set current_tag variable
           - checkout: self
           - script: |
               python3 --version
@@ -75,7 +73,7 @@ stages:
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
               IDPAY_TARGET_ENV: ${{ parameters.env }}
-              TAGS: '$(behave_tag)'
+              TAGS: '$(current_tag)'
             continueOnError: true
           - task: PublishTestResults@2
             inputs:

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ behave_tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.current_tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -19,7 +19,6 @@ variables:
   # Project root folder
   projectRoot: $(System.DefaultWorkingDirectory)/$(working-dir)
   selfHostedAgentPool: 'cstar-uat-linux'
-  TIME_OUT: 10
 
 pool:
   vmImage: 'ubuntu-22.04'

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,12 +70,12 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $(TAGS)
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $TAGS
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
               IDPAY_TARGET_ENV: ${{ parameters.env }}
-              TAGS: ${{variables.behave_tag}}
+              TAGS: '$(behave_tag)'
             continueOnError: true
           - task: PublishTestResults@2
             inputs:

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.behave_tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ behave_tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -52,6 +52,24 @@ stages:
               current_tag: 'onboarding'
             transaction:
               current_tag: 'transaction'
+            cancellation:
+              current_tag: 'cancellation'
+            readmission:
+              current_tag: 'readmission,suspension'
+            refunds:
+              current_tag: 'refunds'
+            unsubscribe:
+              current_tag: 'unsubscribe'
+            family:
+              current_tag: 'family'
+            bar_code:
+              current_tag: 'bar_code'
+            idpay_code:
+              current_tag: 'idpay_code'
+            ranking:
+              current_tag: 'ranking'
+
+        #            AGGIUNGI TAG
         steps:
           - checkout: self
           - script: |

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -42,6 +42,11 @@ stages:
     dependsOn: [ ]
     pool:
       name: $(selfHostedAgentPool)
+    strategy:
+      matrix:
+        tag:
+          - 'onboarding'
+          - 'transaction'
     jobs:
       - job: "Run_functional_tests"
         steps:
@@ -62,11 +67,11 @@ stages:
               secureFile: '.secrets.yaml'
           - script: |
               if [ -z "${{ parameters.tag }}" ] || [ "${{ parameters.tag }}" = "all_skip" ]; then
-                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags ~@skip
+                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "~skip"
               elif [ "${{ parameters.tag }}" = "all" ]; then
                 python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave"
               else
-                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "@${{ parameters.tag }}"
+                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ parameters.tag }}"
               fi
             displayName: 'Run tests with Behave'
             env:

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -43,7 +43,8 @@ stages:
     pool:
       name: $(selfHostedAgentPool)
     jobs:
-      - job: "Run_functional_tests"
+      - job: "Run_scheduled_functional_tests"
+        condition: eq('${{ parameters.tag }}', '')
         strategy:
           maxParallel: 2
           matrix:
@@ -74,6 +75,45 @@ stages:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
               IDPAY_TARGET_ENV: ${{ parameters.env }}
               TAGS: '$(current_tag)'
+            continueOnError: true
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'tests/reports/behave/*.xml'
+              testRunTitle: 'Behave Results'
+              searchFolder: $(Build.SourcesDirectory)
+              failTaskOnFailedTests: true
+            continueOnError: true
+      - job: "Run_manual_functional_tests"
+        condition: not(eq('${{ parameters.tag }}', ''))
+        steps:
+          - checkout: self
+          - script: |
+              python3 --version
+              pip3 --version
+            displayName: "Display Python version"
+          - script: |
+              python3 --version
+              python3 -m pip install --user pipenv
+              python3 -m pipenv sync
+            displayName: "Install requirements"
+          - task: DownloadSecureFile@1
+            name: idpay_secrets
+            displayName: 'Download IDPay secrets'
+            inputs:
+              secureFile: '.secrets.yaml'
+          - script: |
+              if [ -z "${{ parameters.tag }}" ] || [ "${{ parameters.tag }}" = "all_skip" ]; then
+                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "~skip"
+              elif [ "${{ parameters.tag }}" = "all" ]; then
+                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave"
+              else
+                python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ parameters.tag }}"
+              fi
+            displayName: 'Run tests with Behave'
+            env:
+              IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
+              IDPAY_TARGET_ENV: ${{ parameters.env }}
             continueOnError: true
           - task: PublishTestResults@2
             inputs:

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -23,11 +23,6 @@ variables:
 
 pool:
   vmImage: 'ubuntu-22.04'
-  strategy:
-    matrix:
-      tag:
-        - 'onboarding'
-        - 'transaction'
 
 parameters:
   - name: env
@@ -57,6 +52,8 @@ stages:
             transaction:
               tag: 'transaction'
         steps:
+          - script: echo "##vso[task.setvariable variable=tag]$(tag)"
+            displayName: Set tag variable
           - checkout: self
           - script: |
               python3 --version
@@ -73,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -48,12 +48,12 @@ stages:
           maxParallel: 2
           matrix:
             onboarding:
-              tag: 'onboarding'
+              current_tag: 'onboarding'
             transaction:
-              tag: 'transaction'
+              current_tag: 'transaction'
         steps:
-          - script: echo "##vso[task.setvariable variable=tag]$(tag)"
-            displayName: Set tag variable
+          - script: echo "##vso[task.setvariable variable=current_tag]$(current_tag)"
+            displayName: Set current_tag variable
           - checkout: self
           - script: |
               python3 --version
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.current_tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -23,6 +23,11 @@ variables:
 
 pool:
   vmImage: 'ubuntu-22.04'
+  strategy:
+    matrix:
+      tag:
+        - 'onboarding'
+        - 'transaction'
 
 parameters:
   - name: env
@@ -42,11 +47,6 @@ stages:
     dependsOn: [ ]
     pool:
       name: $(selfHostedAgentPool)
-    strategy:
-      matrix:
-        tag:
-          - 'onboarding'
-          - 'transaction'
     jobs:
       - job: "Run_functional_tests"
         steps:

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -68,8 +68,6 @@ stages:
               current_tag: 'idpay_code'
             ranking:
               current_tag: 'ranking'
-
-        #            AGGIUNGI TAG
         steps:
           - checkout: self
           - script: |

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "$TAGS"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $TAGS
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -52,7 +52,7 @@ stages:
             transaction:
               current_tag: 'transaction'
         steps:
-          - script: echo "##vso[task.setvariable variable=current_tag]$(current_tag)"
+          - script: echo "##vso[task.setvariable variable=behave_tag]$(current_tag)"
             displayName: Set current_tag variable
           - checkout: self
           - script: |
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.current_tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.behave_tag }}"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -85,7 +85,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $TAGS
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $TAGS --tags "~skip"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,11 +70,12 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "${{ variables.current_tag }}"
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags "$TAGS"
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)
               IDPAY_TARGET_ENV: ${{ parameters.env }}
+              TAGS: ${{variables.behave_tag}}
             continueOnError: true
           - task: PublishTestResults@2
             inputs:

--- a/.devops/idpay-functional-testing-discount-flow.yml
+++ b/.devops/idpay-functional-testing-discount-flow.yml
@@ -70,7 +70,7 @@ stages:
             inputs:
               secureFile: '.secrets.yaml'
           - script: |
-              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $TAGS
+              python3 -m pipenv run behave --junit --junit-directory "tests/reports/behave" --tags $(TAGS)
             displayName: 'Run tests with Behave'
             env:
               IDPAY_SECRET_PATH: $(idpay_secrets.secureFilePath)


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to split test runs by tag.
### List of changes
- modify Azure DevOps pipeline.
<!--- Describe your changes in detail -->

### Motivation and context
With this change we avoid time out on single jobs by splitting test runs by tag. An overlapping is unavoidable, thus more tests than a sequential run are displayed in the tab after result publish.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [ ] Test suite

### Test type

- [ ] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `pipenv run pip freeze > requirements.txt`
- `pipenv install -r requirements.txt`

and check for changes.

- [ ] Yes
  - [ ] `requirements.txt`
  - [ ] `Pipfile`
  - [ ] `Pipfile.lock`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
